### PR TITLE
Add renderIndicators and remove coverage command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 .vscode-test
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .vscode-test
 coverage
+debug.log

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "test-coverage.js",
+  "scripts": {
+    "test": "istanbul cover -x \"./test-coverage.js\" --report lcovonly ./node_modules/mocha/bin/_mocha -- -R spec test.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "istanbul": "^0.4.5",
+    "mocha": "^3.2.0"
+  }
+}

--- a/example/test-coverage.js
+++ b/example/test-coverage.js
@@ -1,0 +1,9 @@
+module.exports.test = function test(testNumber) {
+    if(testNumber === 1) {
+        return true;
+    }
+    if(testNumber === 2) {
+        return false;
+    }
+    return "null";
+}

--- a/example/test.js
+++ b/example/test.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const assert   = require('assert');
+const testFunc = require('./test-coverage').test;
+
+describe('test func', function() {
+    it('should not show coverage on lines 5 and 9', function() {
+        var num = testFunc(3);
+        assert(num==="null");
+    });
+});

--- a/package.json
+++ b/package.json
@@ -16,13 +16,18 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:extension.displayCoverage"
+        "onCommand:extension.displayCoverage",
+        "onCommand:extension.removeCoverage"
     ],
     "main": "./out/src/extension",
     "contributes": {
         "commands": [{
             "command": "extension.displayCoverage",
             "title": "Coverage Gutters: Display File Coverage"
+        },
+        {
+            "command": "extension.removeCoverage",
+            "title": "Coverage Gutters: Remove File Coverage"
         }]
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,26 @@
     ],
     "main": "./out/src/extension",
     "contributes": {
+        "configuration": {
+            "title": "coverage-gutters",
+            "properties": {
+                "coverage-gutters.lcovname": {
+                    "type": "string",
+                    "default": "lcov.info",
+                    "description": "name of your lcov file"
+                },
+                "coverage-gutters.highlightlight": {
+                    "type": "string",
+                    "default": "lightgreen",
+                    "description": "light themed highlight for code coverage"
+                },
+                "coverage-gutters.highlightdark": {
+                    "type": "string",
+                    "default": "darkgreen",
+                    "description": "dark themed highlight for code coverage"
+                }
+            }
+        },
         "commands": [{
             "command": "extension.displayCoverage",
             "title": "Coverage Gutters: Display File Coverage"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,10 +9,15 @@ export function activate(context: vscode.ExtensionContext) {
 
     let gutters = new Gutters(vscode.workspace.rootPath);
 
-    let disposable = vscode.commands.registerCommand("extension.displayCoverage", () => {
+    let display = vscode.commands.registerCommand("extension.displayCoverage", () => {
         gutters.displayCoverageForFile(vscode.window.activeTextEditor.document.fileName);
     });
 
-    context.subscriptions.push(disposable);
+    let remove = vscode.commands.registerCommand("extension.removeCoverage", () => {
+        gutters.dispose();
+    });
+
+    context.subscriptions.push(remove);
+    context.subscriptions.push(display);
     context.subscriptions.push(gutters);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,10 +3,7 @@
 import * as vscode from "vscode";
 import {Gutters} from "./gutters";
 
-
 export function activate(context: vscode.ExtensionContext) {
-    console.log("Loaded coverage-gutters!");
-
     let gutters = new Gutters();
 
     let display = vscode.commands.registerCommand("extension.displayCoverage", () => {
@@ -20,4 +17,6 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(remove);
     context.subscriptions.push(display);
     context.subscriptions.push(gutters);
+
+    console.log("Loaded coverage-gutters!");
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,10 +7,10 @@ import {Gutters} from "./gutters";
 export function activate(context: vscode.ExtensionContext) {
     console.log("Loaded coverage-gutters!");
 
-    let gutters = new Gutters(vscode.workspace.rootPath);
+    let gutters = new Gutters();
 
     let display = vscode.commands.registerCommand("extension.displayCoverage", () => {
-        gutters.displayCoverageForFile(vscode.window.activeTextEditor.document.fileName);
+        gutters.displayCoverageForActiveFile();
     });
 
     let remove = vscode.commands.registerCommand("extension.removeCoverage", () => {

--- a/src/gutters.ts
+++ b/src/gutters.ts
@@ -5,19 +5,26 @@ import * as parse from "lcov-parse";
 import {readFile} from "fs";
 
 export class Gutters {
-    private coverageDecorationType = vscode.window.createTextEditorDecorationType({
-        isWholeLine: true,
-        light: {
-            backgroundColor: 'lightgreen',
-
-        },
-        dark: {
-            backgroundColor: 'darkgreen'
-        }
-    });
+    private lcovFileName: string;
+    private coverageDecorationType: vscode.TextEditorDecorationType;
+    private coverageLightBackgroundColour: string;
+    private coverageDarkBackgroundColour: string;
 
     constructor() {
+        const config = vscode.workspace.getConfiguration("coverage-gutters");
+        this.lcovFileName = (config.get("lcovname") ? config.get("lcovname") : "lcov.info") as string;
+        this.coverageLightBackgroundColour = (config.get("highlightlight") ? config.get("highlightlight") : "lightgreen") as string;
+        this.coverageDarkBackgroundColour = (config.get("highlightdark") ? config.get("highlightdark") : "darkgreen") as string;
 
+        this.coverageDecorationType = vscode.window.createTextEditorDecorationType({
+            isWholeLine: true,
+            light: {
+                backgroundColor: this.coverageLightBackgroundColour
+            },
+            dark: {
+                backgroundColor: this.coverageDarkBackgroundColour
+            }
+        });
     }
 
     public async displayCoverageForActiveFile() {
@@ -38,7 +45,7 @@ export class Gutters {
 
     private findLcov(): Promise<string> {
         return new Promise((resolve, reject) => {
-            vscode.workspace.findFiles("**/lcov.info", "**/node_modules/**", 1)
+            vscode.workspace.findFiles("**/" + this.lcovFileName, "**/node_modules/**", 1)
                 .then((uriLcov) => {
                     if(!uriLcov.length) return reject(new Error("Could not find a lcov file!"));
                     return resolve(uriLcov[0].fsPath);

--- a/src/gutters.ts
+++ b/src/gutters.ts
@@ -1,27 +1,42 @@
 'use strict';
 
+import * as vscode from "vscode";
 import * as parse from "lcov-parse";
 import {readFile} from "fs";
 
 export class Gutters {
-    private indicators: Object[];
+    private indicators: vscode.Range[];
     private lcovFile: string;
     private workspacePath: string;
     private lcovPath: string;
+    private activeEditor: vscode.TextEditor;
+
+    private coverageDecorationType = vscode.window.createTextEditorDecorationType({
+        isWholeLine: true,
+        light: {
+            backgroundColor: 'lightgreen',
+
+        },
+        dark: {
+            backgroundColor: 'darkgreen'
+        }
+    });
 
     constructor(workspacePath: string) {
         this.indicators = [];
         this.workspacePath = workspacePath;
         this.lcovPath = this.workspacePath + "/coverage/lcov.info";
+        this.activeEditor = vscode.window.activeTextEditor;
     }
 
     public async displayCoverageForFile(file: string) {
         let lcovFile = await this.loadLcov();
         let coveredLines = await this.findFileAndExtractCoverage(lcovFile, file);
+        let indicators = await this.renderIndicators(coveredLines);
     }
 
     public dispose() {
-        //unrender coverage indicators
+        this.activeEditor.setDecorations(this.coverageDecorationType, []);
     }
 
     public getLcovPath(): string {
@@ -34,6 +49,16 @@ export class Gutters {
 
     public getIndicators(): Object[] {
         return this.indicators;
+    }
+
+    private renderIndicators(lines: Detail[]): Promise<Array<vscode.Range>> {
+        return new Promise<Array<Object>>((resolve, reject) => {
+            let renderLines = lines.map((detail) => {
+                return new vscode.Range(detail.line - 1, 0, detail.line - 1, 0);
+            });
+            this.activeEditor.setDecorations(this.coverageDecorationType, renderLines);
+            return resolve(renderLines);
+        });
     }
 
     private loadLcov() {
@@ -49,10 +74,7 @@ export class Gutters {
         return new Promise<Array<Detail>>((resolve, reject) => {
             parse(lcovFile, (err, data) => {
                 if(err) return reject(err);
-                let section = data.find((section) => {
-                    const relativePath = file.split(this.workspacePath)[1];
-                    return section.file === relativePath
-                });
+                let section = data.find(section => section.file === file);
 
                 if(!section) return reject(new Error("No coverage for file!"));
                 return resolve(section.lines.details);

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -6,11 +6,11 @@ import * as vscode from "vscode";
 import * as myExtension from "../src/extension";
 
 suite("Extension Tests", () => {
-    test("Should activate and have subscriptions length of 2", () => {
+    test("Should activate and have subscriptions length of 3", () => {
         let ctx: vscode.ExtensionContext = <any>{
             subscriptions: []
         };
         myExtension.activate(ctx);
-        assert.equal(ctx.subscriptions.length, 2);
+        assert.equal(ctx.subscriptions.length, 3);
     });
 });

--- a/test/gutters.test.ts
+++ b/test/gutters.test.ts
@@ -6,18 +6,7 @@ import * as vscode from "vscode";
 import {Gutters} from "../src/gutters";
 
 suite("Gutters Tests", () => {
-    test("Should properly setup gutters on initialize", () => {
-        let gutters = new Gutters("fakepath");
-        assert.notEqual(gutters.getIndicators(), undefined);
-        assert.equal(gutters.getWorkspacePath(), "fakepath");
-        assert.equal(gutters.getLcovPath(), "fakepath/coverage/lcov.info");
-    });
-
-    test("Should error when given a fake path to find lcov for", () => {
-        let gutters = new Gutters("fakepath2");
-
-        gutters.displayCoverageForFile("fakepath3").then(() => {
-            assert.equal(true, false);
-        });
+    test("Should setup gutters based on config values with no errors", function() {
+        const gutters = new Gutters();
     });
 });


### PR DESCRIPTION
## Issue: #2 #10 

## Work:
- [x] add renderIndicators
- [x] add decoration type for coverage
- [x] add remove coverage command and wire up dispose
- [x] rework OS agnosticness (remove hard coded paths)
- [x] add config ability for lcov name and highlight colours
- [x] cleanup tests