### PR TITLE
Add relative lcov path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 |Setting | Description
 |--------|------------
 |`coverage-gutters.lcovname`|Allows specification of a custom lcov file name
-|`coverage-gutters.altSfCompare`|Uses an alternative method of comparing lcov source file paths
+|`coverage-gutters.altSfCompare`|Uses a relative method of comparing lcov source file paths
 |`coverage-gutters.highlightlight`|Changes the highlight for light themes
 |`coverage-gutters.highlightdark`|Changes the Highlight for dark themes
 |`coverage-gutters.gutterIconPathDark`|Relative path to an icon in the extension for dark themes

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 |Setting | Description
 |--------|------------
 |`coverage-gutters.lcovname`|Allows specification of a custom lcov file name
+|`coverage-gutters.altSfCompare`|Uses an alternative method of comparing lcov source file paths
 |`coverage-gutters.highlightlight`|Changes the highlight for light themes
 |`coverage-gutters.highlightdark`|Changes the Highlight for dark themes
 |`coverage-gutters.gutterIconPathDark`|Relative path to an icon in the extension for dark themes

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Some examples for the highlight colour are as follows:
 - none ( just missing functionality :) )
 
 ## Release Notes
-### [Changelog](CHANGELOG.mb)
+### [Changelog](https://github.com/ryanluker/vscode-coverage-gutters/releases)
 
 ## Contribution Guidelines
 - test backed code changes

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
                     "default": "lcov.info",
                     "description": "name of your lcov file"
                 },
+                "coverage-gutters.altSfCompare": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "uses an alternative methods of comparing source file paths"
+                },
                 "coverage-gutters.highlightlight": {
                     "type": "string",
                     "default": "rgba(166, 220, 142, 0.75)",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
                 "coverage-gutters.altSfCompare": {
                     "type": "boolean",
                     "default": false,
-                    "description": "uses an alternative methods of comparing source file paths"
+                    "description": "uses an alternative method of comparing lcov source file paths"
                 },
                 "coverage-gutters.highlightlight": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
                 "coverage-gutters.altSfCompare": {
                     "type": "boolean",
                     "default": false,
-                    "description": "uses an alternative method of comparing lcov source file paths"
+                    "description": "uses a relative method of comparing lcov source file paths"
                 },
                 "coverage-gutters.highlightlight": {
                     "type": "string",

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,6 @@ export class Config {
         //Basic configurations
         const rootConfig = this.vscode.getConfiguration("coverage-gutters");
         this.lcovFileName = rootConfig.get("lcovname") as string;
-
         this.altSfCompare = rootConfig.get("altSfCompare") as boolean;
 
         const coverageLightBackgroundColour = rootConfig.get("highlightlight") as string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,9 +3,10 @@ import {VscodeInterface} from "./wrappers/vscode";
 import {TextEditorDecorationType, ExtensionContext} from "vscode";
 
 export interface configStore {
-    lcovFileName: string,
-    coverageDecorationType: TextEditorDecorationType,
-    gutterDecorationType: TextEditorDecorationType
+    lcovFileName: string;
+    coverageDecorationType: TextEditorDecorationType;
+    gutterDecorationType: TextEditorDecorationType;
+    altSfCompare: boolean;
 }
 
 export class Config {
@@ -15,6 +16,7 @@ export class Config {
     private lcovFileName: string;
     private coverageDecorationType: TextEditorDecorationType;
     private gutterDecorationType: TextEditorDecorationType;
+    private altSfCompare: boolean;
 
     constructor(vscode: VscodeInterface, context: ExtensionContext) {
         this.vscode = vscode;
@@ -25,7 +27,8 @@ export class Config {
         return {
             lcovFileName: this.lcovFileName,
             coverageDecorationType: this.coverageDecorationType,
-            gutterDecorationType: this.gutterDecorationType
+            gutterDecorationType: this.gutterDecorationType,
+            altSfCompare: this.altSfCompare
         }
     }
 
@@ -43,6 +46,9 @@ export class Config {
         //Basic configurations
         const rootConfig = this.vscode.getConfiguration("coverage-gutters");
         this.lcovFileName = rootConfig.get("lcovname") as string;
+
+        this.altSfCompare = rootConfig.get("altSfCompare") as boolean;
+
         const coverageLightBackgroundColour = rootConfig.get("highlightlight") as string;
         const coverageDarkBackgroundColour = rootConfig.get("highlightdark") as string;
         const gutterIconPathDark = rootConfig.get("gutterIconPathDark") as string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 'use strict';
-
+import {VscodeInterface} from "./wrappers/vscode";
 import {TextEditorDecorationType, ExtensionContext} from "vscode";
 
 export interface configStore {
@@ -9,24 +9,15 @@ export interface configStore {
 }
 
 export class Config {
-    private createTextEditorDecorationType;
-    private executeCommand;
-    private workspaceConfig;
+    private vscode: VscodeInterface;
     private context: ExtensionContext;
 
     private lcovFileName: string;
     private coverageDecorationType: TextEditorDecorationType;
     private gutterDecorationType: TextEditorDecorationType;
 
-    constructor(
-        createTextEditorDecorationType,
-        executeCommand,
-        workspaceConfig,
-        context: ExtensionContext
-    ) {
-        this.createTextEditorDecorationType = createTextEditorDecorationType;
-        this.executeCommand = executeCommand;
-        this.workspaceConfig = workspaceConfig;
+    constructor(vscode: VscodeInterface, context: ExtensionContext) {
+        this.vscode = vscode;
         this.context = context;
     }
 
@@ -40,24 +31,24 @@ export class Config {
 
     public setup(): configStore {
         //Customizable UI configurations
-        const rootCustomConfig = this.workspaceConfig("coverage-gutters.customizable");
+        const rootCustomConfig = this.vscode.getConfiguration("coverage-gutters.customizable");
         const configsCustom = Object.keys(rootCustomConfig);
         for(let element of configsCustom) {
-            this.executeCommand(
+            this.vscode.executeCommand(
                 "setContext",
                 "config.coverage-gutters.customizable." + element,
                 rootCustomConfig.get(element));
         }
 
         //Basic configurations
-        const rootConfig = this.workspaceConfig("coverage-gutters");
+        const rootConfig = this.vscode.getConfiguration("coverage-gutters");
         this.lcovFileName = rootConfig.get("lcovname") as string;
         const coverageLightBackgroundColour = rootConfig.get("highlightlight") as string;
         const coverageDarkBackgroundColour = rootConfig.get("highlightdark") as string;
         const gutterIconPathDark = rootConfig.get("gutterIconPathDark") as string;
         const gutterIconPathLight = rootConfig.get("gutterIconPathLight") as string;
 
-        this.coverageDecorationType = this.createTextEditorDecorationType({
+        this.coverageDecorationType = this.vscode.createTextEditorDecorationType({
             isWholeLine: true,
             light: {
                 backgroundColor: coverageLightBackgroundColour
@@ -67,7 +58,7 @@ export class Config {
             }
         });
 
-        this.gutterDecorationType = this.createTextEditorDecorationType({
+        this.gutterDecorationType = this.vscode.createTextEditorDecorationType({
             light: {
                 gutterIconPath: this.context.asAbsolutePath(gutterIconPathLight)
             },

--- a/src/indicators.ts
+++ b/src/indicators.ts
@@ -4,7 +4,7 @@ import {configStore} from "./config";
 import {LcovParseInterface} from "./wrappers/lcov-parse";
 import {VscodeInterface} from "./wrappers/vscode";
 
-import {Range, workspace} from "vscode";
+import {Range} from "vscode";
 import {Detail} from "lcov-parse";
 
 export interface indicators {
@@ -60,7 +60,7 @@ export class Indicators implements indicators{
             //consider windows and linux file paths
             const sourceFile = lcovFile.split(/[\\\/]/).reverse();
             const openFile = file.split(/[\\\/]/).reverse();
-            const folderName = workspace.rootPath.split(/[\\\/]/).reverse()[0];
+            const folderName = this.vscode.getRootPath().split(/[\\\/]/).reverse()[0];
             let match = true;
             let index = 0;
 

--- a/src/lcov.ts
+++ b/src/lcov.ts
@@ -4,8 +4,8 @@ import {VscodeInterface} from "./wrappers/vscode";
 import {FsInterface} from "./wrappers/fs";
 
 export interface lcov {
-    find(): Promise<string>,
-    load(lcovPath: string): Promise<string>
+    find(): Promise<string>;
+    load(lcovPath: string): Promise<string>;
 }
 
 export class Lcov implements lcov {

--- a/src/lcov.ts
+++ b/src/lcov.ts
@@ -1,5 +1,7 @@
 'use strict';
 import {configStore} from "./config";
+import {VscodeInterface} from "./wrappers/vscode";
+import {FsInterface} from "./wrappers/fs";
 
 export interface lcov {
     find(): Promise<string>,
@@ -8,18 +10,22 @@ export interface lcov {
 
 export class Lcov implements lcov {
     private configStore: configStore;
-    private findFiles;
-    private readFile;
+    private vscode: VscodeInterface;
+    private fs: FsInterface;
 
-    constructor(configStore: configStore, findFiles, readFile) {
+    constructor(
+        configStore: configStore,
+        vscode: VscodeInterface,
+        fs: FsInterface
+    ) {
         this.configStore = configStore;
-        this.findFiles = findFiles;
-        this.readFile = readFile;
+        this.vscode = vscode;
+        this.fs = fs;
     }
 
     public find(): Promise<string> {
         return new Promise((resolve, reject) => {
-            this.findFiles("**/" + this.configStore.lcovFileName, "**/node_modules/**", 1)
+            this.vscode.findFiles("**/" + this.configStore.lcovFileName, "**/node_modules/**", 1)
                 .then((uriLcov) => {
                     if(!uriLcov.length) return reject(new Error("Could not find a lcov file!"));
                     return resolve(uriLcov[0].fsPath);
@@ -29,7 +35,7 @@ export class Lcov implements lcov {
 
     public load(lcovPath: string): Promise<string> {
         return new Promise<string>((resolve, reject) => {
-            this.readFile(lcovPath, (err, data) => {
+            this.fs.readFile(lcovPath, (err, data) => {
                 if(err) return reject(err);
                 return resolve(data.toString());
             });

--- a/src/wrappers/fs.ts
+++ b/src/wrappers/fs.ts
@@ -1,5 +1,12 @@
 import {readFile as readFileFS} from "fs";
 
-export function readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void) {
-    return readFileFS(filename, callback);
+export interface FsInterface {
+    readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void
 }
+
+export class fs implements FsInterface {
+    public readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void {
+        return readFileFS(filename, callback);
+    }
+}
+

--- a/src/wrappers/fs.ts
+++ b/src/wrappers/fs.ts
@@ -1,7 +1,7 @@
 import {readFile as readFileFS} from "fs";
 
 export interface FsInterface {
-    readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void
+    readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
 }
 
 export class fs implements FsInterface {

--- a/src/wrappers/lcov-parse.ts
+++ b/src/wrappers/lcov-parse.ts
@@ -1,7 +1,13 @@
 "use strict";
 
-import {LcovSection, source} from "lcov-parse";
+import {LcovSection, source as sourceLcovParse} from "lcov-parse";
 
-export function lcovParse(file: string, cb: (err: Error, data: Array<LcovSection>) => void): void {
-    return source(file, cb);
+export interface LcovParseInterface {
+    source(file: string, cb: (err: Error, data: Array<LcovSection>) => void): void
+}
+
+export class lcovParse implements LcovParseInterface {
+    public source(file: string, cb: (err: Error, data: Array<LcovSection>) => void): void {
+        return sourceLcovParse(file, cb);
+    }
 }

--- a/src/wrappers/lcov-parse.ts
+++ b/src/wrappers/lcov-parse.ts
@@ -3,7 +3,7 @@
 import {LcovSection, source as sourceLcovParse} from "lcov-parse";
 
 export interface LcovParseInterface {
-    source(file: string, cb: (err: Error, data: Array<LcovSection>) => void): void
+    source(file: string, cb: (err: Error, data: Array<LcovSection>) => void): void;
 }
 
 export class lcovParse implements LcovParseInterface {

--- a/src/wrappers/vscode.ts
+++ b/src/wrappers/vscode.ts
@@ -14,11 +14,11 @@ import {
 } from "vscode"
 
 export interface VscodeInterface {
-    createTextEditorDecorationType(options: DecorationRenderOptions): TextEditorDecorationType,
-    setDecorations(decorationType: TextEditorDecorationType, rangesOrOptions: Range[] | DecorationOptions[]): void,
-    executeCommand(command: string, ...rest: any[]): Thenable<{}>,
-    findFiles(include: string, exclude: string, maxResults?: number, token?: CancellationToken): Thenable<Uri[]>,
-    getConfiguration(section?: string): WorkspaceConfiguration
+    createTextEditorDecorationType(options: DecorationRenderOptions): TextEditorDecorationType;
+    setDecorations(decorationType: TextEditorDecorationType, rangesOrOptions: Range[] | DecorationOptions[]): void;
+    executeCommand(command: string, ...rest: any[]): Thenable<{}>;
+    findFiles(include: string, exclude: string, maxResults?: number, token?: CancellationToken): Thenable<Uri[]>;
+    getConfiguration(section?: string): WorkspaceConfiguration;
 }
 
 export class vscode implements VscodeInterface {

--- a/src/wrappers/vscode.ts
+++ b/src/wrappers/vscode.ts
@@ -1,7 +1,9 @@
 "use strict";
 
-import {window, commands, workspace} from "vscode";
 import {
+    window,
+    commands,
+    workspace,
     DecorationRenderOptions,
     TextEditorDecorationType,
     WorkspaceConfiguration,
@@ -11,22 +13,32 @@ import {
     Uri
 } from "vscode"
 
-export function createTextEditorDecorationType(options: DecorationRenderOptions): TextEditorDecorationType {
-    return window.createTextEditorDecorationType(options);
+export interface VscodeInterface {
+    createTextEditorDecorationType(options: DecorationRenderOptions): TextEditorDecorationType,
+    setDecorations(decorationType: TextEditorDecorationType, rangesOrOptions: Range[] | DecorationOptions[]): void,
+    executeCommand(command: string, ...rest: any[]): Thenable<{}>,
+    findFiles(include: string, exclude: string, maxResults?: number, token?: CancellationToken): Thenable<Uri[]>,
+    getConfiguration(section?: string): WorkspaceConfiguration
 }
 
-export function setDecorations(decorationType: TextEditorDecorationType, rangesOrOptions: Range[] | DecorationOptions[]) {
-    return window.activeTextEditor.setDecorations(decorationType, rangesOrOptions);
-}
+export class vscode implements VscodeInterface {
+    public createTextEditorDecorationType(options: DecorationRenderOptions): TextEditorDecorationType {
+        return window.createTextEditorDecorationType(options);
+    }
 
-export function executeCommand(command: string, ...rest: any[]): Thenable<{}> {
-    return commands.executeCommand(command, rest);
-}
+    public setDecorations(decorationType: TextEditorDecorationType, rangesOrOptions: Range[] | DecorationOptions[]) {
+        return window.activeTextEditor.setDecorations(decorationType, rangesOrOptions);
+    }
 
-export function findFiles(include: string, exclude: string, maxResults?: number, token?: CancellationToken): Thenable<Uri[]> {
-    return workspace.findFiles(include, exclude, maxResults, token);
-}
+    public executeCommand(command: string, ...rest: any[]): Thenable<{}> {
+        return commands.executeCommand(command, rest);
+    }
 
-export function getConfiguration(section?: string): WorkspaceConfiguration {
-    return workspace.getConfiguration(section);
+    public findFiles(include: string, exclude: string, maxResults?: number, token?: CancellationToken): Thenable<Uri[]> {
+        return workspace.findFiles(include, exclude, maxResults, token);
+    }
+
+    public getConfiguration(section?: string): WorkspaceConfiguration {
+        return workspace.getConfiguration(section);
+    }
 }

--- a/src/wrappers/vscode.ts
+++ b/src/wrappers/vscode.ts
@@ -19,6 +19,7 @@ export interface VscodeInterface {
     executeCommand(command: string, ...rest: any[]): Thenable<{}>;
     findFiles(include: string, exclude: string, maxResults?: number, token?: CancellationToken): Thenable<Uri[]>;
     getConfiguration(section?: string): WorkspaceConfiguration;
+    getRootPath(): string;
 }
 
 export class vscode implements VscodeInterface {
@@ -40,5 +41,9 @@ export class vscode implements VscodeInterface {
 
     public getConfiguration(section?: string): WorkspaceConfiguration {
         return workspace.getConfiguration(section);
+    }
+
+    public getRootPath(): string {
+        return workspace.rootPath;
     }
 }

--- a/test/indicators.test.ts
+++ b/test/indicators.test.ts
@@ -2,11 +2,83 @@
 
 import * as assert from "assert";
 
-import * as vscode from "vscode";
+import {vscode} from "../src/wrappers/vscode";
+import {lcovParse} from "../src/wrappers/lcov-parse";
 import {Indicators} from "../src/indicators";
 
 suite("Indicators Tests", function() {
-    test("Constructor should setup properly", function() {
+    const fakeConfig = {
+        lcovFileName: "test.ts",
+        coverageDecorationType: {
+            key: "testKey",
+            dispose() {}
+        },
+        gutterDecorationType: {
+            key: "testKey2",
+            dispose() {}
+        },
+        altSfCompare: false
+    };
 
+    test("Constructor should setup properly", function(done) {
+        try {
+            const vscodeImpl = new vscode();
+            const parseImpl = new lcovParse();
+            const indicators = new Indicators(
+                parseImpl,
+                vscodeImpl,
+                fakeConfig
+            );
+            return done();
+        } catch(e) {
+            assert.equal(1,2);
+            return done();
+        }
+    });
+
+    test("#extract: should find a matching file with absolute match mode", function(done) {
+        fakeConfig.altSfCompare = false;
+        const vscodeImpl = new vscode();
+        const parseImpl = new lcovParse();
+
+        const fakeLcov = "TN:\nSF:c:\/dev\/vscode-coverage-gutters\/example\/test-coverage.js\nDA:1,1\nend_of_record";
+        const fakeFile = "c:\/dev\/vscode-coverage-gutters\/example\/test-coverage.js";
+        const indicators = new Indicators(
+            parseImpl,
+            vscodeImpl,
+            fakeConfig
+        );
+
+        indicators.extract(fakeLcov, fakeFile)
+            .then(function(data) {
+                assert.equal(data.length, 1);
+                return done();
+            })
+            .catch(function(error) {
+                return done(error);
+            });
+    });
+
+    test("#extract: should find a matching file with relative match mode", function(done) {
+        fakeConfig.altSfCompare = true;
+        const vscodeImpl = new vscode();
+        vscodeImpl.getRootPath = function() { return "vscode-coverage-gutters"; };
+        const parseImpl = new lcovParse();
+        const fakeLinuxLcov = "TN:\nSF:/mnt/c/dev/vscode-coverage-gutters/example/test-coverage.js\nDA:1,1\nend_of_record";
+        const fakeFile = "c:\/dev\/vscode-coverage-gutters\/example\/test-coverage.js";
+        const indicators = new Indicators(
+            parseImpl,
+            vscodeImpl,
+            fakeConfig
+        );
+
+        indicators.extract(fakeLinuxLcov, fakeFile)
+            .then(function(data) {
+                assert.equal(data.length, 1);
+                return done();
+            })
+            .catch(function(error) {
+                return done(error);
+            });
     });
 });

--- a/test/lcov.test.ts
+++ b/test/lcov.test.ts
@@ -7,22 +7,25 @@ import {fs} from "../src/wrappers/fs";
 import {Lcov} from "../src/lcov";
 
 suite("Lcov Tests", function() {
+    const fakeConfig = {
+        lcovFileName: "test.ts",
+        coverageDecorationType: {
+            key: "testKey",
+            dispose() {}
+        },
+        gutterDecorationType: {
+            key: "testKey2",
+            dispose() {}
+        },
+        altSfCompare: true
+    };
+
     test("Constructor should setup properly", function(done) {
         try {
             const vscodeImpl = new vscode();
             const fsImpl = new fs();
             const lcov = new Lcov(
-                {
-                    lcovFileName: "test.ts",
-                    coverageDecorationType: {
-                        key: "testKey",
-                        dispose() {}
-                    },
-                    gutterDecorationType: {
-                        key: "testKey2",
-                        dispose() {}
-                    }
-                },
+                fakeConfig,
                 vscodeImpl,
                 fsImpl
             );
@@ -46,17 +49,7 @@ suite("Lcov Tests", function() {
             });
         };
         const lcov = new Lcov(
-            {
-                lcovFileName: "test.ts",
-                coverageDecorationType: {
-                    key: "testKey",
-                    dispose() {}
-                },
-                gutterDecorationType: {
-                    key: "testKey2",
-                    dispose() {}
-                }
-            },
+            fakeConfig,
             vscodeImpl,
             fsImpl
         );
@@ -85,17 +78,7 @@ suite("Lcov Tests", function() {
             });
         };
         const lcov = new Lcov(
-            {
-                lcovFileName: "test.ts",
-                coverageDecorationType: {
-                    key: "testKey",
-                    dispose() {}
-                },
-                gutterDecorationType: {
-                    key: "testKey2",
-                    dispose() {}
-                }
-            },
+            fakeConfig,
             vscodeImpl,
             fsImpl
         );
@@ -120,17 +103,7 @@ suite("Lcov Tests", function() {
             return cb(error, null);
         };
         const lcov = new Lcov(
-            {
-                lcovFileName: "test.ts",
-                coverageDecorationType: {
-                    key: "testKey",
-                    dispose() {}
-                },
-                gutterDecorationType: {
-                    key: "testKey2",
-                    dispose() {}
-                }
-            },
+            fakeConfig,
             vscodeImpl,
             fsImpl
         );
@@ -155,17 +128,7 @@ suite("Lcov Tests", function() {
             return cb(null, new Buffer("lcovhere"));
         };
         const lcov = new Lcov(
-            {
-                lcovFileName: "test.ts",
-                coverageDecorationType: {
-                    key: "testKey",
-                    dispose() {}
-                },
-                gutterDecorationType: {
-                    key: "testKey2",
-                    dispose() {}
-                }
-            },
+            fakeConfig,
             vscodeImpl,
             fsImpl
         );


### PR DESCRIPTION
## Issues: #29 #30 
## Work:
- [x] fix changelog link
- [x] add type safest via interfaces to extracted classes
- [x] add relative lcov path option
- [x] add more test coverage

## QA:
- [x] check relative solution on macos
- [x] check relative solution on windows
- [x] check relative solution on windows with coverage generated by bash on windows