### PR TITLE
Enhanced coverage displaying

### DIFF
--- a/example/test-coverage.js
+++ b/example/test-coverage.js
@@ -2,9 +2,14 @@ module.exports.test = function test(testNumber) {
     if(testNumber === 1) {
         return true;
     }
+    if(testNumber === 5) {
+        return "reallyReally";
+    }
+
     if(testNumber === 2) {
         return false;
     }
     if(testNumber === 3) return "notNull";
+    if(testNumber === 4) return "reallyNull";
     return "null";
 }

--- a/example/test-coverage.js
+++ b/example/test-coverage.js
@@ -5,5 +5,6 @@ module.exports.test = function test(testNumber) {
     if(testNumber === 2) {
         return false;
     }
+    if(testNumber === 3) return "notNull";
     return "null";
 }

--- a/example/test-coverage.js
+++ b/example/test-coverage.js
@@ -2,14 +2,14 @@ module.exports.test = function test(testNumber) {
     if(testNumber === 1) {
         return true;
     }
-    if(testNumber === 5) {
-        return "reallyReally";
-    }
-
     if(testNumber === 2) {
         return false;
     }
+
     if(testNumber === 3) return "notNull";
     if(testNumber === 4) return "reallyNull";
-    return "null";
+
+    testNumber = testNumber === 5 ? "woop":"wap";
+
+    return testNumber;
 }

--- a/example/test.js
+++ b/example/test.js
@@ -10,12 +10,17 @@ describe('test func', function() {
     });
 
     it('should show coverage on line 6', function() {
-        var num = testFunc(2);
-        assert(num===false);
-    });
-
-    it('should show  coverage on line 9', function() {
         var num = testFunc(4);
         assert(num==="reallyNull");
+    });
+
+    it('should show coverage on line 9', function() {
+        var num = testFunc(6);
+        assert(num==="wap");
+    });
+
+    it('should show coverage on line 9 x2', function() {
+        var num = testFunc(5);
+        assert(num==="woop");
     });
 });

--- a/example/test.js
+++ b/example/test.js
@@ -5,7 +5,7 @@ const testFunc = require('./test-coverage').test;
 
 describe('test func', function() {
     it('should show coverage on line 8', function() {
-        var num = testFunc(3);
+        var num = testFunc(4);
         assert(num==="null");
     });
 

--- a/example/test.js
+++ b/example/test.js
@@ -5,12 +5,17 @@ const testFunc = require('./test-coverage').test;
 
 describe('test func', function() {
     it('should show coverage on line 8', function() {
-        var num = testFunc(4);
-        assert(num==="null");
+        var num = testFunc(1);
+        assert(num===true);
     });
 
     it('should show coverage on line 6', function() {
         var num = testFunc(2);
         assert(num===false);
+    });
+
+    it('should show  coverage on line 9', function() {
+        var num = testFunc(4);
+        assert(num==="reallyNull");
     });
 });

--- a/images/gutter-icon-dark.svg
+++ b/images/gutter-icon-dark.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0" x="0px" y="0px" viewBox="0 0 48 48" class="icon icons8-Checkmark" ><polygon fill="#24381B" points="40.6,12.1 17,35.7 7.4,26.1 4.6,29 17,41.3 43.4,14.9 "></polygon></svg>
+<svg width="32" height="48" viewPort="0 0 32 48"
+    xmlns="http://www.w3.org/2000/svg">
+  <polygon points="16,0 32,0 32,48 16,48" fill="#24381B"/>
+</svg>

--- a/images/no-gutter-icon-dark.svg
+++ b/images/no-gutter-icon-dark.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="48" viewPort="0 0 32 48"
+    xmlns="http://www.w3.org/2000/svg">
+  <polygon points="16,0 32,0 32,48 16,48" fill="#391B1B"/>
+</svg>

--- a/images/no-gutter-icon-light.svg
+++ b/images/no-gutter-icon-light.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="48" viewPort="0 0 32 48"
+    xmlns="http://www.w3.org/2000/svg">
+  <polygon points="16,0 32,0 32,48 16,48" fill="#DC8E8E"/>
+</svg>

--- a/images/partial-gutter-icon-dark.svg
+++ b/images/partial-gutter-icon-dark.svg
@@ -1,4 +1,4 @@
 <svg width="32" height="48" viewPort="0 0 32 48"
     xmlns="http://www.w3.org/2000/svg">
-  <polygon points="16,0 32,0 32,48 16,48" fill="#A6DC8E"/>
+  <polygon points="16,0 32,0 32,48 16,48" fill="#39321B"/>
 </svg>

--- a/images/partial-gutter-icon-light.svg
+++ b/images/partial-gutter-icon-light.svg
@@ -1,4 +1,4 @@
 <svg width="32" height="48" viewPort="0 0 32 48"
     xmlns="http://www.w3.org/2000/svg">
-  <polygon points="16,0 32,0 32,48 16,48" fill="#A6DC8E"/>
+  <polygon points="16,0 32,0 32,48 16,48" fill="#DCC88F"/>
 </svg>

--- a/package.json
+++ b/package.json
@@ -53,15 +53,35 @@
                     "default": "rgba(36, 56, 27, 0.75)",
                     "description": "dark themed highlight for code coverage"
                 },
-                "coverage-gutters.gutterIconPathDark": {
+                "coverage-gutters.partialHighlightLight": {
                     "type": "string",
-                    "default": "./images/gutter-icon-dark.svg",
-                    "description": "path to an icon (svg, png, etc) for displaying in the gutter for dark themes"
+                    "default": "rgba(220, 213, 143, 0.75)",
+                    "description": "light theme partial highlight for code coverage"
+                },
+                "coverage-gutters.partialHighlightDark": {
+                    "type": "string",
+                    "default": "rgba(57, 50, 27, 0.75)",
+                    "description": "dark theme partial highlight for code coverage"
                 },
                 "coverage-gutters.gutterIconPathLight": {
                     "type": "string",
                     "default": "./images/gutter-icon-light.svg",
-                    "description": "path to an icon (svg, png, etc) for displaying in the gutter for light themes"
+                    "description": "path to an icon (svg, png, etc) for displaying in the gutter for full coverage"
+                },
+                "coverage-gutters.gutterIconPathDark": {
+                    "type": "string",
+                    "default": "./images/gutter-icon-dark.svg",
+                    "description": "path to an icon (svg, png, etc) for displaying in the gutter for full coverage"
+                },
+                "coverage-gutters.partialGutterIconPathLight": {
+                    "type": "string",
+                    "default": "./images/partial-gutter-icon-light.svg",
+                    "description": "path to an icon (svg, png, etc) for displaying in the gutter for partial coverage"
+                },
+                "coverage-gutters.partialGutterIconPathDark": {
+                    "type": "string",
+                    "default": "./images/partial-gutter-icon-dark.svg",
+                    "description": "path to an icon (svg, png, etc) for displaying in the gutter for partial coverage"
                 },
                 "coverage-gutters.customizable.menus-editor-context-displayCoverage-enabled": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,16 @@
                     "default": "rgba(57, 50, 27, 0.75)",
                     "description": "dark theme partial highlight for code coverage"
                 },
+                "coverage-gutters.noHighlightLight": {
+                    "type": "string",
+                    "default": "rgba(220, 213, 143, 0.75)",
+                    "description": "light theme partial highlight for code coverage"
+                },
+                "coverage-gutters.noHighlightDark": {
+                    "type": "string",
+                    "default": "rgba(57, 27, 27, 0.75)",
+                    "description": "dark theme partial highlight for code coverage"
+                },
                 "coverage-gutters.gutterIconPathLight": {
                     "type": "string",
                     "default": "./images/gutter-icon-light.svg",
@@ -82,6 +92,16 @@
                     "type": "string",
                     "default": "./images/partial-gutter-icon-dark.svg",
                     "description": "path to an icon (svg, png, etc) for displaying in the gutter for partial coverage"
+                },
+                "coverage-gutters.noGutterIconPathLight": {
+                    "type": "string",
+                    "default": "./images/no-gutter-icon-light.svg",
+                    "description": "path to an icon (svg, png, etc) for displaying in the gutter for no coverage"
+                },
+                "coverage-gutters.noGutterIconPathDark": {
+                    "type": "string",
+                    "default": "./images/no-gutter-icon-dark.svg",
+                    "description": "path to an icon (svg, png, etc) for displaying in the gutter for no coverage"
                 },
                 "coverage-gutters.customizable.menus-editor-context-displayCoverage-enabled": {
                     "type": "boolean",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,20 +1,25 @@
-import {ExtensionContext, TextEditorDecorationType} from "vscode";
+import {ExtensionContext, OverviewRulerLane, TextEditorDecorationType} from "vscode";
 import {InterfaceVscode} from "./wrappers/vscode";
 
 export type ConfigStore = {
     lcovFileName: string;
-    coverageDecorationType: TextEditorDecorationType;
-    gutterDecorationType: TextEditorDecorationType;
+    fullCoverageDecorationType: TextEditorDecorationType;
+    partialCoverageDecorationType: TextEditorDecorationType;
     altSfCompare: boolean;
 };
+
+export interface InterfaceConfig {
+    get(): ConfigStore;
+    setup(): ConfigStore;
+}
 
 export class Config {
     private vscode: InterfaceVscode;
     private context: ExtensionContext;
 
     private lcovFileName: string;
-    private coverageDecorationType: TextEditorDecorationType;
-    private gutterDecorationType: TextEditorDecorationType;
+    private fullCoverageDecorationType: TextEditorDecorationType;
+    private partialCoverageDecorationType: TextEditorDecorationType;
     private altSfCompare: boolean;
 
     constructor(vscode: InterfaceVscode, context: ExtensionContext) {
@@ -25,9 +30,9 @@ export class Config {
     public get(): ConfigStore {
         return {
             altSfCompare: this.altSfCompare,
-            coverageDecorationType: this.coverageDecorationType,
-            gutterDecorationType: this.gutterDecorationType,
+            fullCoverageDecorationType: this.fullCoverageDecorationType,
             lcovFileName: this.lcovFileName,
+            partialCoverageDecorationType: this.partialCoverageDecorationType,
         };
     }
 
@@ -49,26 +54,41 @@ export class Config {
 
         const coverageLightBackgroundColour = rootConfig.get("highlightlight") as string;
         const coverageDarkBackgroundColour = rootConfig.get("highlightdark") as string;
+        const partialCoverageLightBackgroundColour = rootConfig.get("partialHighlightLight") as string;
+        const partialCoverageDarkBackgroundColour = rootConfig.get("partialHighlightDark") as string;
         const gutterIconPathDark = rootConfig.get("gutterIconPathDark") as string;
         const gutterIconPathLight = rootConfig.get("gutterIconPathLight") as string;
+        const partialGutterIconPathDark = rootConfig.get("partialGutterIconPathDark") as string;
+        const partialGutterIconPathLight = rootConfig.get("partialGutterIconPathLight") as string;
 
-        this.coverageDecorationType = this.vscode.createTextEditorDecorationType({
+        this.fullCoverageDecorationType = this.vscode.createTextEditorDecorationType({
             dark: {
                 backgroundColor: coverageDarkBackgroundColour,
+                gutterIconPath: this.context.asAbsolutePath(gutterIconPathDark),
+                overviewRulerColor: coverageDarkBackgroundColour,
             },
             isWholeLine: true,
             light: {
                 backgroundColor: coverageLightBackgroundColour,
+                gutterIconPath: this.context.asAbsolutePath(gutterIconPathLight),
+                overviewRulerColor: coverageLightBackgroundColour,
             },
+            overviewRulerLane: OverviewRulerLane.Full,
         });
 
-        this.gutterDecorationType = this.vscode.createTextEditorDecorationType({
+        this.partialCoverageDecorationType = this.vscode.createTextEditorDecorationType({
             dark: {
-                gutterIconPath: this.context.asAbsolutePath(gutterIconPathDark),
+                backgroundColor: partialCoverageDarkBackgroundColour,
+                gutterIconPath: this.context.asAbsolutePath(partialGutterIconPathDark),
+                overviewRulerColor: partialCoverageDarkBackgroundColour,
             },
+            isWholeLine: true,
             light: {
-                gutterIconPath: this.context.asAbsolutePath(gutterIconPathLight),
+                backgroundColor: partialCoverageLightBackgroundColour,
+                gutterIconPath: this.context.asAbsolutePath(partialGutterIconPathLight),
+                overviewRulerColor: partialCoverageLightBackgroundColour,
             },
+            overviewRulerLane: OverviewRulerLane.Full,
         });
 
         return this.get();

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export type ConfigStore = {
     lcovFileName: string;
     fullCoverageDecorationType: TextEditorDecorationType;
     partialCoverageDecorationType: TextEditorDecorationType;
+    noCoverageDecorationType: TextEditorDecorationType;
     altSfCompare: boolean;
 };
 
@@ -20,6 +21,7 @@ export class Config {
     private lcovFileName: string;
     private fullCoverageDecorationType: TextEditorDecorationType;
     private partialCoverageDecorationType: TextEditorDecorationType;
+    private noCoverageDecorationType: TextEditorDecorationType;
     private altSfCompare: boolean;
 
     constructor(vscode: InterfaceVscode, context: ExtensionContext) {
@@ -32,6 +34,7 @@ export class Config {
             altSfCompare: this.altSfCompare,
             fullCoverageDecorationType: this.fullCoverageDecorationType,
             lcovFileName: this.lcovFileName,
+            noCoverageDecorationType: this.noCoverageDecorationType,
             partialCoverageDecorationType: this.partialCoverageDecorationType,
         };
     }
@@ -52,14 +55,19 @@ export class Config {
         this.lcovFileName = rootConfig.get("lcovname") as string;
         this.altSfCompare = rootConfig.get("altSfCompare") as boolean;
 
+        // Themes and icons
         const coverageLightBackgroundColour = rootConfig.get("highlightlight") as string;
         const coverageDarkBackgroundColour = rootConfig.get("highlightdark") as string;
         const partialCoverageLightBackgroundColour = rootConfig.get("partialHighlightLight") as string;
         const partialCoverageDarkBackgroundColour = rootConfig.get("partialHighlightDark") as string;
+        const noCoverageLightBackgroundColour = rootConfig.get("noHighlightLight") as string;
+        const noCoverageDarkBackgroundColour = rootConfig.get("noHighlightDark") as string;
         const gutterIconPathDark = rootConfig.get("gutterIconPathDark") as string;
         const gutterIconPathLight = rootConfig.get("gutterIconPathLight") as string;
         const partialGutterIconPathDark = rootConfig.get("partialGutterIconPathDark") as string;
         const partialGutterIconPathLight = rootConfig.get("partialGutterIconPathLight") as string;
+        const noGutterIconPathDark = rootConfig.get("noGutterIconPathDark") as string;
+        const noGutterIconPathLight = rootConfig.get("noGutterIconPathLight") as string;
 
         this.fullCoverageDecorationType = this.vscode.createTextEditorDecorationType({
             dark: {
@@ -87,6 +95,21 @@ export class Config {
                 backgroundColor: partialCoverageLightBackgroundColour,
                 gutterIconPath: this.context.asAbsolutePath(partialGutterIconPathLight),
                 overviewRulerColor: partialCoverageLightBackgroundColour,
+            },
+            overviewRulerLane: OverviewRulerLane.Full,
+        });
+
+        this.noCoverageDecorationType = this.vscode.createTextEditorDecorationType({
+            dark: {
+                backgroundColor: noCoverageDarkBackgroundColour,
+                gutterIconPath: this.context.asAbsolutePath(noGutterIconPathDark),
+                overviewRulerColor: noCoverageDarkBackgroundColour,
+            },
+            isWholeLine: true,
+            light: {
+                backgroundColor: noCoverageLightBackgroundColour,
+                gutterIconPath: this.context.asAbsolutePath(noGutterIconPathLight),
+                overviewRulerColor: noCoverageLightBackgroundColour,
             },
             overviewRulerLane: OverviewRulerLane.Full,
         });

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export interface InterfaceConfig {
     setup(): ConfigStore;
 }
 
-export class Config {
+export class Config implements InterfaceConfig {
     private vscode: InterfaceVscode;
     private context: ExtensionContext;
 

--- a/src/gutters.ts
+++ b/src/gutters.ts
@@ -77,8 +77,7 @@ export class Gutters {
 
     private removeDecorationsForTextEditor(editor: TextEditor) {
         if (!editor) { return; }
-        editor.setDecorations(this.configStore.coverageDecorationType, []);
-        editor.setDecorations(this.configStore.gutterDecorationType, []);
+        editor.setDecorations(this.configStore.fullCoverageDecorationType, []);
     }
 
     private async loadAndRenderCoverage(textEditor: TextEditor, lcovPath: string): Promise<void> {

--- a/src/indicators.ts
+++ b/src/indicators.ts
@@ -33,8 +33,7 @@ export class Indicators implements InterfaceIndicators {
                     renderLines.push(new Range(detail.line - 1, 0, detail.line - 1, 0));
                 }
             });
-            textEditor.setDecorations(this.configStore.coverageDecorationType, renderLines);
-            textEditor.setDecorations(this.configStore.gutterDecorationType, renderLines);
+            textEditor.setDecorations(this.configStore.fullCoverageDecorationType, renderLines);
             return resolve();
         });
     }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -3,7 +3,7 @@
 import * as assert from "assert";
 
 import * as vscode from "vscode";
-import {Config} from "../../src/config";
+import {Config} from "../src/config";
 
 suite("Config Tests", function() {
     test("Constructor should setup properly", function() {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 
 import * as vscode from "vscode";
-import * as myExtension from "../../src/extension";
+import * as myExtension from "../src/extension";
 
 suite("Extension Tests", function() {
     test("Should not active a second extension instance", function(done) {

--- a/test/gutters.test.ts
+++ b/test/gutters.test.ts
@@ -3,7 +3,7 @@
 import * as assert from "assert";
 
 import * as vscode from "vscode";
-import {Gutters} from "../../src/gutters";
+import {Gutters} from "../src/gutters";
 
 suite("Gutters Tests", function() {
     test("Should setup gutters based on config values with no errors", function(done) {

--- a/test/indicators.test.ts
+++ b/test/indicators.test.ts
@@ -224,7 +224,6 @@ suite("Indicators Tests", function() {
             });
     });
 
-
     test("#extract: should find a matching file with absolute match mode", function(done) {
         fakeConfig.altSfCompare = false;
         const vscodeImpl = new Vscode();

--- a/test/indicators.test.ts
+++ b/test/indicators.test.ts
@@ -96,6 +96,135 @@ suite("Indicators Tests", function() {
             });
     });
 
+    test("#renderToTextEditor: should remove full coverage if partial on same line", function(done) {
+        let callsToSetDecorations = 0;
+
+        const vscodeImpl = new Vscode();
+        const parseImpl = new LcovParse();
+        const indicators = new Indicators(
+            parseImpl,
+            vscodeImpl,
+            fakeConfig,
+        );
+
+        const fakeSection: LcovSection = {
+            branches: {
+                details: [{
+                    block: 0,
+                    branch: 0,
+                    line: 10,
+                    taken: 0,
+                }],
+                found: 1,
+                hit: 1,
+            },
+            file: "test",
+            functions: {
+                details: [],
+                found: 1,
+                hit: 1,
+            },
+            lines: {
+                details: [{
+                    hit: 1,
+                    line: 10,
+                }],
+                found: 1,
+                hit: 1,
+            },
+        };
+
+        const fakeTextEditor: any = {
+            setDecorations(decorType, ranges) {
+                callsToSetDecorations++;
+                switch (callsToSetDecorations) {
+                    case 4: {
+                        assert.equal(ranges.length, 0);
+                        return;
+                    }
+                    case 6: {
+                        assert.equal(ranges.length, 1);
+                        return;
+                    }
+                    default:
+                        return;
+                }
+            },
+        };
+
+        indicators.renderToTextEditor(fakeSection, fakeTextEditor)
+            .then(function() {
+                return done();
+            })
+            .catch(function(error) {
+                return done(error);
+            });
+    });
+
+    test("#renderToTextEditor: should render full coverage and no coverage", function(done) {
+        let callsToSetDecorations = 0;
+
+        const vscodeImpl = new Vscode();
+        const parseImpl = new LcovParse();
+        const indicators = new Indicators(
+            parseImpl,
+            vscodeImpl,
+            fakeConfig,
+        );
+
+        const fakeSection: LcovSection = {
+            branches: {
+                details: [],
+                found: 1,
+                hit: 1,
+            },
+            file: "test",
+            functions: {
+                details: [],
+                found: 1,
+                hit: 1,
+            },
+            lines: {
+                details: [{
+                    hit: 1,
+                    line: 10,
+                }, {
+                    hit: 0,
+                    line: 5,
+                }],
+                found: 1,
+                hit: 1,
+            },
+        };
+
+        const fakeTextEditor: any = {
+            setDecorations(decorType, ranges) {
+                callsToSetDecorations++;
+                switch (callsToSetDecorations) {
+                    case 4: {
+                        assert.equal(ranges.length, 1);
+                        return;
+                    }
+                    case 5: {
+                        assert.equal(ranges.length, 1);
+                        return;
+                    }
+                    default:
+                        return;
+                }
+            },
+        };
+
+        indicators.renderToTextEditor(fakeSection, fakeTextEditor)
+            .then(function() {
+                return done();
+            })
+            .catch(function(error) {
+                return done(error);
+            });
+    });
+
+
     test("#extract: should find a matching file with absolute match mode", function(done) {
         fakeConfig.altSfCompare = false;
         const vscodeImpl = new Vscode();

--- a/test/indicators.test.ts
+++ b/test/indicators.test.ts
@@ -1,10 +1,12 @@
 "use strict";
 
 import * as assert from "assert";
+import {BranchDetail, LcovSection} from "lcov-parse";
+import {TextEditor} from "vscode";
 
-import {Indicators} from "../../src/indicators";
-import {LcovParse} from "../../src/wrappers/lcov-parse";
-import {Vscode} from "../../src/wrappers/vscode";
+import {Indicators} from "../src/indicators";
+import {LcovParse} from "../src/wrappers/lcov-parse";
+import {Vscode} from "../src/wrappers/vscode";
 
 suite("Indicators Tests", function() {
     const fakeConfig = {
@@ -38,6 +40,60 @@ suite("Indicators Tests", function() {
             assert.equal(1, 2);
             return done();
         }
+    });
+
+    test("#renderToTextEditor: should set basic coverage", function(done) {
+        let callsToSetDecorations = 0;
+
+        const vscodeImpl = new Vscode();
+        const parseImpl = new LcovParse();
+        const indicators = new Indicators(
+            parseImpl,
+            vscodeImpl,
+            fakeConfig,
+        );
+
+        const fakeSection: LcovSection = {
+            branches: {
+                details: [],
+                found: 1,
+                hit: 1,
+            },
+            file: "test",
+            functions: {
+                details: [],
+                found: 1,
+                hit: 1,
+            },
+            lines: {
+                details: [{
+                    hit: 1,
+                    line: 10,
+                }],
+                found: 1,
+                hit: 1,
+            },
+        };
+
+        const fakeTextEditor: any = {
+            setDecorations(decorType, ranges) {
+                callsToSetDecorations++;
+                if (callsToSetDecorations !== 4) {
+                    return;
+                } else {
+                    assert.equal(ranges.length, 1);
+                    return;
+                }
+            },
+        };
+
+        indicators.renderToTextEditor(fakeSection, fakeTextEditor)
+            .then(function() {
+                return done();
+            })
+            .catch(function(error) {
+                return done(error);
+            });
     });
 
     test("#extract: should find a matching file with absolute match mode", function(done) {

--- a/test/integration/indicators.test.ts
+++ b/test/integration/indicators.test.ts
@@ -14,6 +14,10 @@ suite("Indicators Tests", function() {
             dispose() {},
         },
         lcovFileName: "test.ts",
+        noCoverageDecorationType: {
+            key: "testKey4",
+            dispose() {},
+        },
         partialCoverageDecorationType: {
             key: "testKey3",
             dispose() {},
@@ -51,7 +55,7 @@ suite("Indicators Tests", function() {
 
         indicators.extract(fakeLcov, fakeFile)
             .then(function(data) {
-                assert.equal(data.length, 1);
+                assert.equal(data.lines.details.length, 1);
                 return done();
             })
             .catch(function(error) {
@@ -75,7 +79,7 @@ suite("Indicators Tests", function() {
 
         indicators.extract(fakeLinuxLcov, fakeFile)
             .then(function(data) {
-                assert.equal(data.length, 1);
+                assert.equal(data.lines.details.length, 1);
                 return done();
             })
             .catch(function(error) {

--- a/test/integration/indicators.test.ts
+++ b/test/integration/indicators.test.ts
@@ -9,15 +9,15 @@ import {Vscode} from "../../src/wrappers/vscode";
 suite("Indicators Tests", function() {
     const fakeConfig = {
         altSfCompare: false,
-        coverageDecorationType: {
+        fullCoverageDecorationType: {
             key: "testKey",
             dispose() {},
         },
-        gutterDecorationType: {
-            key: "testKey2",
+        lcovFileName: "test.ts",
+        partialCoverageDecorationType: {
+            key: "testKey3",
             dispose() {},
         },
-        lcovFileName: "test.ts",
     };
 
     test("Constructor should setup properly", function(done) {

--- a/test/integration/lcov.test.ts
+++ b/test/integration/lcov.test.ts
@@ -8,12 +8,16 @@ import {Vscode} from "../../src/wrappers/vscode";
 
 suite("Lcov Tests", function() {
     const fakeConfig = {
-        altSfCompare: true,
+        altSfCompare: false,
         fullCoverageDecorationType: {
             key: "testKey",
             dispose() {},
         },
         lcovFileName: "test.ts",
+        noCoverageDecorationType: {
+            key: "testKey4",
+            dispose() {},
+        },
         partialCoverageDecorationType: {
             key: "testKey3",
             dispose() {},

--- a/test/integration/lcov.test.ts
+++ b/test/integration/lcov.test.ts
@@ -9,15 +9,15 @@ import {Vscode} from "../../src/wrappers/vscode";
 suite("Lcov Tests", function() {
     const fakeConfig = {
         altSfCompare: true,
-        coverageDecorationType: {
+        fullCoverageDecorationType: {
             key: "testKey",
             dispose() {},
         },
-        gutterDecorationType: {
-            key: "testKey2",
+        lcovFileName: "test.ts",
+        partialCoverageDecorationType: {
+            key: "testKey3",
             dispose() {},
         },
-        lcovFileName: "test.ts",
     };
 
     test("Constructor should setup properly", function(done) {

--- a/test/lcov.test.ts
+++ b/test/lcov.test.ts
@@ -2,9 +2,9 @@
 
 import * as assert from "assert";
 
-import {Lcov} from "../../src/lcov";
-import {Fs} from "../../src/wrappers/fs";
-import {Vscode} from "../../src/wrappers/vscode";
+import {Lcov} from "../src/lcov";
+import {Fs} from "../src/wrappers/fs";
+import {Vscode} from "../src/wrappers/vscode";
 
 suite("Lcov Tests", function() {
     const fakeConfig = {

--- a/test/system/extension.test.ts
+++ b/test/system/extension.test.ts
@@ -5,6 +5,7 @@ import * as myExtension from "../../src/extension";
 
 suite("Extension Tests", function() {
     test("Should not active a second extension instance", function(done) {
+        this.timeout(12000);
         let ctx: vscode.ExtensionContext = <any> {
             asAbsolutePath() {
                 return "test";

--- a/types/lcov-parse/index.d.ts
+++ b/types/lcov-parse/index.d.ts
@@ -1,21 +1,46 @@
 declare namespace parse {
     function source(str: string, cb: (err: Error, data: Array<LcovSection>) => void): void
 
-    interface Detail {
+    interface LineDetail {
         hit: number,
         line: number
     }
 
+    interface BranchDetail {
+        block: number,
+        branch: number,
+        line: number,
+        taken: number
+    }
+
+    interface FunctionDetail {
+        hit: number,
+        line: number,
+        name: string
+    }
+
     interface Lines {
-        details: Array<Detail>,
+        details: Array<LineDetail>,
+        hit: number,
+        found: number
+    }
+
+    interface Branches {
+        details: Array<BranchDetail>,
+        hit: number,
+        found: number
+    }
+
+    interface Functions {
+        details: Array<FunctionDetail>,
         hit: number,
         found: number
     }
 
     interface LcovSection {
-        branches: Object,
+        branches: Branches,
         file: string,
-        functions: Object,
+        functions: Functions,
         lines: Lines
     }
 }


### PR DESCRIPTION
## Issue: #27 #37 

## Work:
- [x] rework gutter icon to be more readable
- [x] rework config decoration setup to be more lean
- [x] fix tests
- [x] add partial decoration skeleton
- [x] wire up partial coverage
- [x] add tests to cover partial coverage option
- [x] wire up not covered coverage
- [x] add tests to cover not covered coverage option

## Design: 
coverage being shown for full, partial and none
![new-coverage-styles](https://cloud.githubusercontent.com/assets/1335972/24442379/acb2cb8e-1412-11e7-9cc5-ae0f791f81a9.PNG)
