### PR TITLE
Display caught errors and prevent lcov error

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,3 +10,5 @@ tsconfig.json
 appveyor.yml
 example/**
 .vscodeignore
+types/**
+tslint.json

--- a/src/gutters.ts
+++ b/src/gutters.ts
@@ -36,8 +36,8 @@ export class Gutters {
         try {
             const lcovPath = await this.lcov.find();
             await this.loadAndRenderCoverage(textEditor, lcovPath);
-        } catch (e) {
-            console.log(e);
+        } catch (error) {
+            this.handleError(error);
         }
     }
 
@@ -60,8 +60,8 @@ export class Gutters {
                     }
                 });
             });
-        } catch (e) {
-            console.log(e);
+        } catch (error) {
+            this.handleError(error);
         }
     }
 
@@ -78,6 +78,11 @@ export class Gutters {
 
     public getTextEditors(): TextEditor[] {
         return this.textEditors;
+    }
+
+    private handleError(error: Error) {
+        const message = error.message ? error.message : error;
+        window.showErrorMessage(message.toString());
     }
 
     private addTextEditorToCache(editor: TextEditor) {

--- a/src/lcov.ts
+++ b/src/lcov.ts
@@ -24,9 +24,10 @@ export class Lcov implements InterfaceLcov {
 
     public find(): Promise<string> {
         return new Promise((resolve, reject) => {
-            this.vscode.findFiles("**/" + this.configStore.lcovFileName, "**/node_modules/**", 1)
+            this.vscode.findFiles("**/" + this.configStore.lcovFileName, "**/node_modules/**")
                 .then((uriLcov) => {
                     if (!uriLcov || !uriLcov.length) { return reject("Could not find a lcov file!"); }
+                    if (uriLcov.length > 1) { return reject("More then one lcov file found!"); }
                     return resolve(uriLcov[0].fsPath);
                 });
         });

--- a/test/lcov.test.ts
+++ b/test/lcov.test.ts
@@ -40,6 +40,34 @@ suite("Lcov Tests", function() {
         }
     });
 
+    test("#find: Should return error if more then one file found for lcovFileName", function(done) {
+        const vscodeImpl = new Vscode();
+        const fsImpl = new Fs();
+
+        vscodeImpl.findFiles = function(path, exclude) {
+            assert.equal(path, "**/test.ts");
+            assert.equal(exclude, "**/node_modules/**");
+            return new Promise(function(resolve, reject) {
+                return resolve([1, 2]);
+            });
+        };
+        const lcov = new Lcov(
+            fakeConfig,
+            vscodeImpl,
+            fsImpl,
+        );
+
+        lcov.find()
+            .then(function() {
+                return done(new Error("Expected error did not fire!"));
+            })
+            .catch(function(error) {
+                if (error.name === "AssertionError") { return done(error); }
+                if (error === "More then one lcov file found!") { return done(); }
+                return done(error);
+            });
+    });
+
     test("#find: Should return error if no file found for lcovFileName", function(done) {
         const vscodeImpl = new Vscode();
         const fsImpl = new Fs();
@@ -47,7 +75,6 @@ suite("Lcov Tests", function() {
         vscodeImpl.findFiles = function(path, exclude, filesToFind) {
             assert.equal(path, "**/test.ts");
             assert.equal(exclude, "**/node_modules/**");
-            assert.equal(filesToFind, 1);
             return new Promise(function(resolve, reject) {
                 return resolve([]);
             });
@@ -76,7 +103,6 @@ suite("Lcov Tests", function() {
         vscodeImpl.findFiles = function(path, exclude, filesToFind) {
             assert.equal(path, "**/test.ts");
             assert.equal(exclude, "**/node_modules/**");
-            assert.equal(filesToFind, 1);
             return new Promise(function(resolve, reject) {
                 return resolve([{fsPath: "path/to/greatness/test.ts"}]);
             });


### PR DESCRIPTION
## Issues: #35, #39 
## Work: 
- [x] add error handling and displaying
- [x] prevent more then one lcov from being consumed (provide feedback)
- [x] cleanup published files

## Design:
![design-could-not-find-file](https://cloud.githubusercontent.com/assets/1335972/24595718/1b4b27ba-17ee-11e7-8e4b-d44a1ba9a761.PNG)
