### PR TITLE
Add option to hide status bar item and general cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 |`coverage-gutters.showLineCoverage`|Show or hide the line coverage
 |`coverage-gutters.showRulerCoverage`|Show or hide the ruler coverage
 |`coverage-gutters.showGutterCoverage`|Show or hide the gutter coverage
+|`coverage-gutters.customizable.status-bar-toggler-watchLcovAndVisibleEditors-enabled`|Setting this to false will remove the status bar item
 |`coverage-gutters.customizable.menus-editor-context-displayCoverage-enabled`|Setting this to false will remove the command from the editor context menu and vice versa
 |`coverage-gutters.customizable.menus-editor-context-watchLcovFile-enabled`|Setting this to false will remove the command from the editor context menu and vice versa
 |`coverage-gutters.customizable.menus-editor-context-watchVisibleEditors-enabled`|Setting this to false will remove the command from the editor context menu and vice versa

--- a/example/test-coverage.js
+++ b/example/test-coverage.js
@@ -11,5 +11,20 @@ module.exports.test = function test(testNumber) {
 
     testNumber = testNumber === 5 ? "woop":"wap";
 
+    const testComplexReturn = callbackBased(111, subTest);
+
+    if(testNumber === 6) {
+        testNumber = testNumber ? subTest(testNumber) : "neverhappen";
+    }
+
     return testNumber;
+}
+
+function callbackBased(testNumber, done) {
+    return done(testNumber.toString());
+}
+
+function subTest(testString) {
+    testString = testString.toString();
+    return testString.toUpperCase();
 }

--- a/example/test.js
+++ b/example/test.js
@@ -15,7 +15,7 @@ describe('test func', function() {
     });
 
     it('should show coverage on line 9', function() {
-        var num = testFunc(6);
+        var num = testFunc(7);
         assert(num==="wap");
     });
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
           "default": true,
           "description": "show or hide the gutter coverage"
         },
+        "coverage-gutters.customizable.status-bar-toggler-watchLcovAndVisibleEditors-enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "enable or disable the status bar item"
+        },
         "coverage-gutters.customizable.menus-editor-context-displayCoverage-enabled": {
           "type": "boolean",
           "default": true,
@@ -238,6 +243,7 @@
     "test-ci": "npm run lint && npm test --silent",
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -watch -p ./",
+    "build": "npm install && npm run lint && tsc -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export interface IConfigStore {
     partialCoverageDecorationType: TextEditorDecorationType;
     noCoverageDecorationType: TextEditorDecorationType;
     altSfCompare: boolean;
+    showStatusBarToggler: boolean;
 }
 
 export class Config {
@@ -26,6 +27,7 @@ export class Config {
     private partialCoverageDecorationType: TextEditorDecorationType;
     private noCoverageDecorationType: TextEditorDecorationType;
     private altSfCompare: boolean;
+    private showStatusBarToggler: boolean;
 
     constructor(vscode: InterfaceVscode, context: ExtensionContext, reporter: Reporter) {
         this.vscode = vscode;
@@ -41,6 +43,7 @@ export class Config {
             lcovFileName: this.lcovFileName,
             noCoverageDecorationType: this.noCoverageDecorationType,
             partialCoverageDecorationType: this.partialCoverageDecorationType,
+            showStatusBarToggler: this.showStatusBarToggler,
         };
     }
 
@@ -61,6 +64,8 @@ export class Config {
         // Basic configurations
         this.lcovFileName = rootConfig.get("lcovname") as string;
         this.altSfCompare = rootConfig.get("altSfCompare") as boolean;
+        const STATUS_BAR_TOGGLER = "status-bar-toggler-watchLcovAndVisibleEditors-enabled";
+        this.showStatusBarToggler = rootCustomConfig.get(STATUS_BAR_TOGGLER) as boolean;
         this.reporter.sendEvent("config", "lcovFileName", this.lcovFileName);
         this.reporter.sendEvent("config", "altSfCompare", this.altSfCompare.toString());
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,8 +18,8 @@ const vscodeImpl = new Vscode();
 export function activate(context: vscode.ExtensionContext) {
     const enableMetrics = vscode.workspace.getConfiguration("telemetry").get("enableTelemetry") as boolean;
     const reporter = new Reporter(new Request(), new Uuid(), "", enableMetrics);
-    const statusBarToggler = new StatusBarToggler();
     const configStore = new Config(vscodeImpl, context, reporter).get();
+    const statusBarToggler = new StatusBarToggler(configStore);
     const lcov = new Lcov(configStore, vscodeImpl, fsImpl);
     const indicators = new Indicators(parseImpl, vscodeImpl, configStore);
     const gutters = new Gutters(configStore, lcov, indicators, reporter, statusBarToggler);

--- a/src/gutters.ts
+++ b/src/gutters.ts
@@ -118,8 +118,6 @@ export class Gutters {
         const file = textEditor.document.fileName;
         const coveredLines = await this.indicators.extract(lcovFile, file);
         await this.indicators.renderToTextEditor(coveredLines, textEditor);
-
-        this.reporter.sendEvent("user", "loadAndRenderCoverage");
     }
 
     private renderCoverageOnVisible(lcovPath: string) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -2,7 +2,7 @@ import {Request} from "./wrappers/request";
 import {Uuid} from "./wrappers/uuid";
 
 const EXT_NAME = "vscode-coverage-gutters";
-const EXT_VERSION = "0.5.0";
+const EXT_VERSION = "0.6.0";
 
 export class Reporter {
     private readonly cid: string;

--- a/src/statusbartoggler.ts
+++ b/src/statusbartoggler.ts
@@ -1,4 +1,5 @@
 import {Disposable, StatusBarItem, window} from "vscode";
+import {IConfigStore} from "./config";
 
 export class StatusBarToggler implements Disposable {
     public static readonly watchCommand = "extension.watchLcovAndVisibleEditors";
@@ -7,13 +8,15 @@ export class StatusBarToggler implements Disposable {
     public static readonly removeText = "$(list-ordered) Remove Watch";
     public static readonly toolTip = "Coverage Gutters: Watch and Remove Helper";
     private statusBarItem: StatusBarItem;
+    private configStore: IConfigStore;
 
-    constructor() {
+    constructor(configStore: IConfigStore) {
         this.statusBarItem = window.createStatusBarItem();
         this.statusBarItem.command = StatusBarToggler.watchCommand;
         this.statusBarItem.text = StatusBarToggler.watchText;
         this.statusBarItem.tooltip = StatusBarToggler.toolTip;
-        this.statusBarItem.show();
+        this.configStore = configStore;
+        if (this.configStore.showStatusBarToggler) { this.statusBarItem.show(); }
     }
 
     /**

--- a/src/statusbartoggler.ts
+++ b/src/statusbartoggler.ts
@@ -2,11 +2,11 @@ import {Disposable, StatusBarItem, window} from "vscode";
 import {IConfigStore} from "./config";
 
 export class StatusBarToggler implements Disposable {
-    public static readonly watchCommand = "extension.watchLcovAndVisibleEditors";
-    public static readonly removeCommand = "extension.removeWatch";
-    public static readonly watchText = "$(list-ordered) Watch Lcov and Editors";
-    public static readonly removeText = "$(list-ordered) Remove Watch";
-    public static readonly toolTip = "Coverage Gutters: Watch and Remove Helper";
+    private static readonly watchCommand = "extension.watchLcovAndVisibleEditors";
+    private static readonly removeCommand = "extension.removeWatch";
+    private static readonly watchText = "$(list-ordered) Watch Lcov and Editors";
+    private static readonly removeText = "$(list-ordered) Remove Watch";
+    private static readonly toolTip = "Coverage Gutters: Watch and Remove Helper";
     private statusBarItem: StatusBarItem;
     private configStore: IConfigStore;
 

--- a/test/gutters.test.ts
+++ b/test/gutters.test.ts
@@ -34,11 +34,9 @@ suite("Gutters Tests", function() {
     });
 
     test("Should not error when trying to render coverage on empty editor", async function() {
-        let sendEventTimes = 0;
         try {
             const reporter: Reporter = {
                 sendEvent(cat, action) {
-                    sendEventTimes++;
                     return;
                 },
             } as any;
@@ -70,7 +68,6 @@ suite("Gutters Tests", function() {
 
             const gutters = new Gutters(configStore, lcov, indicators, reporter, statusbar);
             await gutters.displayCoverageForActiveFile();
-            assert.equal(sendEventTimes, 3);
         } catch (error) {
             throw error;
         }

--- a/test/gutters.test.ts
+++ b/test/gutters.test.ts
@@ -70,7 +70,7 @@ suite("Gutters Tests", function() {
 
             const gutters = new Gutters(configStore, lcov, indicators, reporter, statusbar);
             await gutters.displayCoverageForActiveFile();
-            assert.equal(sendEventTimes, 2);
+            assert.equal(sendEventTimes, 3);
         } catch (error) {
             throw error;
         }

--- a/test/indicators.test.ts
+++ b/test/indicators.test.ts
@@ -22,6 +22,7 @@ suite("Indicators Tests", function() {
             key: "testKey3",
             dispose() {},
         },
+        showStatusBarToggler: true,
     };
 
     test("Constructor should setup properly", function(done) {

--- a/test/lcov.test.ts
+++ b/test/lcov.test.ts
@@ -19,6 +19,7 @@ suite("Lcov Tests", function() {
             key: "testKey3",
             dispose() {},
         },
+        showStatusBarToggler: true,
     };
 
     test("Constructor should setup properly", function(done) {

--- a/test/statusbartoggler.test.ts
+++ b/test/statusbartoggler.test.ts
@@ -1,0 +1,34 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import {IConfigStore} from "../src/config";
+import {StatusBarToggler} from "../src/statusbartoggler";
+
+suite("Status Bar Toggler Tests", function() {
+    const fakeConfig = {
+        altSfCompare: false,
+        fullCoverageDecorationType: {
+            key: "testKey",
+            dispose() {},
+        },
+        lcovFileName: "test.ts",
+        noCoverageDecorationType: {
+            key: "testKey4",
+            dispose() {},
+        },
+        partialCoverageDecorationType: {
+            key: "testKey3",
+            dispose() {},
+        },
+        showStatusBarToggler: false,
+    };
+
+    test("Should toggle showStatusBarToggler command and message", function() {
+        const statusBarToggler = new StatusBarToggler(fakeConfig);
+        statusBarToggler.toggle();
+    });
+
+    test("Should dispose when asked", function() {
+        const statusBarToggler = new StatusBarToggler(fakeConfig);
+        statusBarToggler.dispose();
+    });
+});


### PR DESCRIPTION
### Issues:
- [x] #62 
- [x] #64 
- [x] #59 
- [x] #60

### Work:
- [x] cleanup versioning for reporter
- [x] investigate code coverage issue
- [x] add option to not show the status bar toggler (aka auto coverage show and hide)
- [x] add new dev helper npm scripts
- [x] update readme with new option for not rendering status bar item