### PR TITLE
Update dark colours and show defaults

### DIFF
--- a/images/gutter-icon-dark.svg
+++ b/images/gutter-icon-dark.svg
@@ -1,4 +1,4 @@
 <svg width="32" height="48" viewPort="0 0 32 48"
     xmlns="http://www.w3.org/2000/svg">
-  <polygon points="16,0 32,0 32,48 16,48" fill="#24381B"/>
+  <polygon points="16,0 32,0 32,48 16,48" fill="#2D790A"/>
 </svg>

--- a/images/no-gutter-icon-dark.svg
+++ b/images/no-gutter-icon-dark.svg
@@ -1,4 +1,4 @@
 <svg width="32" height="48" viewPort="0 0 32 48"
     xmlns="http://www.w3.org/2000/svg">
-  <polygon points="16,0 32,0 32,48 16,48" fill="#391B1B"/>
+  <polygon points="16,0 32,0 32,48 16,48" fill="#791F0A"/>
 </svg>

--- a/images/partial-gutter-icon-dark.svg
+++ b/images/partial-gutter-icon-dark.svg
@@ -1,4 +1,4 @@
 <svg width="32" height="48" viewPort="0 0 32 48"
     xmlns="http://www.w3.org/2000/svg">
-  <polygon points="16,0 32,0 32,48 16,48" fill="#39321B"/>
+  <polygon points="16,0 32,0 32,48 16,48" fill="#79560A"/>
 </svg>

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         },
         "coverage-gutters.highlightdark": {
           "type": "string",
-          "default": "rgba(36, 56, 27, 0.75)",
+          "default": "rgba(45, 121, 10, 0.75)",
           "description": "dark themed highlight for code coverage"
         },
         "coverage-gutters.partialHighlightLight": {
@@ -60,7 +60,7 @@
         },
         "coverage-gutters.partialHighlightDark": {
           "type": "string",
-          "default": "rgba(57, 50, 27, 0.75)",
+          "default": "rgba(121, 86, 10, 0.75)",
           "description": "dark theme partial highlight for code coverage"
         },
         "coverage-gutters.noHighlightLight": {
@@ -70,7 +70,7 @@
         },
         "coverage-gutters.noHighlightDark": {
           "type": "string",
-          "default": "rgba(57, 27, 27, 0.75)",
+          "default": "rgba(121, 31, 10, 0.75)",
           "description": "dark theme partial highlight for code coverage"
         },
         "coverage-gutters.gutterIconPathLight": {

--- a/package.json
+++ b/package.json
@@ -105,12 +105,12 @@
         },
         "coverage-gutters.showLineCoverage": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "show or hide the line coverage"
         },
         "coverage-gutters.showRulerCoverage": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "show or hide the ruler coverage"
         },
         "coverage-gutters.showGutterCoverage": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,7 @@ export class Config {
         const showGutterCoverage = rootConfig.get("showGutterCoverage") as string;
         const showLineCoverage = rootConfig.get("showLineCoverage") as string;
         const showRulerCoverage = rootConfig.get("showRulerCoverage") as string;
+        this.reporter.sendEvent("config", "showGutterCoverage", showGutterCoverage);
         this.reporter.sendEvent("config", "showLineCoverage", showLineCoverage);
         this.reporter.sendEvent("config", "showRulerCoverage", showRulerCoverage);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,8 @@ export class Config {
         const showGutterCoverage = rootConfig.get("showGutterCoverage") as string;
         const showLineCoverage = rootConfig.get("showLineCoverage") as string;
         const showRulerCoverage = rootConfig.get("showRulerCoverage") as string;
+        this.reporter.sendEvent("config", "showLineCoverage", showLineCoverage);
+        this.reporter.sendEvent("config", "showRulerCoverage", showRulerCoverage);
 
         const fullDecoration: DecorationRenderOptions = {
             dark: {


### PR DESCRIPTION
## Issue: #69 

## Work: 
- [x] use new dark theme colours that have nicer visibility
- [x] show only gutters coverage by default
- [x] add metrics to capture how many go back to line and ruler