### PR TITLE
Fix issue with unix style file paths

### DIFF
--- a/src/gutters.ts
+++ b/src/gutters.ts
@@ -62,7 +62,7 @@ export class Gutters {
             }
 
             if (!pickedReport) { throw new Error("Could not show Lcov Report file!"); }
-            const reportUri = Uri.parse(`file:///${pickedReport}`);
+            const reportUri = Uri.file(pickedReport.toString());
             await commands.executeCommand(
                 "vscode.previewHtml",
                 reportUri,

--- a/src/lcov.ts
+++ b/src/lcov.ts
@@ -36,7 +36,7 @@ export class Lcov {
     public findReports(): Promise<string[]> {
         return new Promise<string[]>((resolve, reject) => {
             this.glob.find(
-                `**/coverage/**/*.html`,
+                `**/coverage/**/index.html`,
                 { ignore: "**/node_modules/**", cwd: this.vscode.getRootPath(), realpath: true },
                 (err, files) => {
                     if (!files || !files.length) { return reject("Could not find a Lcov Report file!"); }


### PR DESCRIPTION
## Issue:
- unix environment was throwing errors when trying to preview lcov report with preview 1.1.0 release

 ## Work:
- [x] implement uri.file instead of parse to fix unix pathing issues