### PR TITLE
Add simple cache.

### DIFF
--- a/src/gutters.ts
+++ b/src/gutters.ts
@@ -106,7 +106,8 @@ export class Gutters {
             this.loadAndRenderCoverage(textEditor, pickedFile).catch(() => {});
 
             this.coverageWatcher = vscodeImpl.watchFile(pickedFile);
-            this.coverageWatcher.onDidChange((event) => this.renderCoverageOnVisible(pickedFile));
+            this.coverageWatcher.onDidChange(
+                (event) => this.renderCoverageOnChange(pickedFile));
             this.editorWatcher = window.onDidChangeVisibleTextEditors(
                 (event) => this.renderCoverageOnVisible(pickedFile));
             this.statusBar.toggle();
@@ -181,5 +182,10 @@ export class Gutters {
             if (!editor) { return; }
             await this.loadAndRenderCoverage(editor, coveragePath);
         });
+    }
+
+    private renderCoverageOnChange(coveragePath: string) {
+        this.indicators.clearCoverageCache();
+        this.renderCoverageOnVisible(coveragePath);
     }
 }


### PR DESCRIPTION
Hi @ryanluker !

Every switch between tabs is running extraction. I am working with quite big coverage file and this results in considerable lag in displaying coverage. After a while this becomes mildly distracting.

I've seen that you are planning to add some caching in future but please consider this PR as intermediate solution.