### PR TITLE
Show coverage only to files that match exactly

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
           "default": "cov.xml",
           "description": "name of your xml file"
         },
+        "coverage-gutters.matchNameExact": {
+          "type": "boolean",
+          "default": false,
+          "description": "match lcov source file only if exactness score = 100"
+        },
         "coverage-gutters.altSfCompare": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
           "default": "cov.xml",
           "description": "name of your xml file"
         },
-        "coverage-gutters.matchNameExact": {
-          "type": "boolean",
-          "default": false,
-          "description": "match lcov source file only if exactness score = 100"
+        "coverage-gutters.sectionMatchThreshold": {
+          "type": "number",
+          "default": 50,
+          "description": "match lcov source file only if exactness score >= threshold"
         },
         "coverage-gutters.altSfCompare": {
           "type": "boolean",

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ export interface IConfigStore {
     noCoverageDecorationType: TextEditorDecorationType;
     altSfCompare: boolean;
     showStatusBarToggler: boolean;
+    sectionMatchThreshold: number;
 }
 
 export class Config {
@@ -29,7 +30,7 @@ export class Config {
     private partialCoverageDecorationType: TextEditorDecorationType;
     private noCoverageDecorationType: TextEditorDecorationType;
     private altSfCompare: boolean;
-    private matchNameExact: boolean;
+    private sectionMatchThreshold: number;
     private showStatusBarToggler: boolean;
 
     constructor(vscode: InterfaceVscode, context: ExtensionContext, reporter: Reporter) {
@@ -48,7 +49,7 @@ export class Config {
             partialCoverageDecorationType: this.partialCoverageDecorationType,
             showStatusBarToggler: this.showStatusBarToggler,
             xmlFileName: this.xmlFileName,
-            matchNameExact: this.matchNameExact,
+            sectionMatchThreshold: this.sectionMatchThreshold,
         };
     }
 
@@ -70,7 +71,7 @@ export class Config {
         this.lcovFileName = rootConfig.get("lcovname") as string;
         this.xmlFileName = rootConfig.get("xmlname") as string;
         this.altSfCompare = rootConfig.get("altSfCompare") as boolean;
-        this.matchNameExact = rootConfig.get("matchNameExact") as boolean;
+        this.sectionMatchThreshold = rootConfig.get("sectionMatchThreshold") as number;
         const STATUS_BAR_TOGGLER = "status-bar-toggler-watchCoverageAndVisibleEditors-enabled";
         this.showStatusBarToggler = rootCustomConfig.get(STATUS_BAR_TOGGLER) as boolean;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export class Config {
     private partialCoverageDecorationType: TextEditorDecorationType;
     private noCoverageDecorationType: TextEditorDecorationType;
     private altSfCompare: boolean;
+    private matchNameExact: boolean;
     private showStatusBarToggler: boolean;
 
     constructor(vscode: InterfaceVscode, context: ExtensionContext, reporter: Reporter) {
@@ -47,6 +48,7 @@ export class Config {
             partialCoverageDecorationType: this.partialCoverageDecorationType,
             showStatusBarToggler: this.showStatusBarToggler,
             xmlFileName: this.xmlFileName,
+            matchNameExact: this.matchNameExact,
         };
     }
 
@@ -68,6 +70,7 @@ export class Config {
         this.lcovFileName = rootConfig.get("lcovname") as string;
         this.xmlFileName = rootConfig.get("xmlname") as string;
         this.altSfCompare = rootConfig.get("altSfCompare") as boolean;
+        this.matchNameExact = rootConfig.get("matchNameExact") as boolean;
         const STATUS_BAR_TOGGLER = "status-bar-toggler-watchCoverageAndVisibleEditors-enabled";
         this.showStatusBarToggler = rootCustomConfig.get(STATUS_BAR_TOGGLER) as boolean;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,8 +15,8 @@ export interface IConfigStore {
     partialCoverageDecorationType: TextEditorDecorationType;
     noCoverageDecorationType: TextEditorDecorationType;
     altSfCompare: boolean;
-    showStatusBarToggler: boolean;
     sectionMatchThreshold: number;
+    showStatusBarToggler: boolean;
 }
 
 export class Config {
@@ -47,9 +47,9 @@ export class Config {
             lcovFileName: this.lcovFileName,
             noCoverageDecorationType: this.noCoverageDecorationType,
             partialCoverageDecorationType: this.partialCoverageDecorationType,
+            sectionMatchThreshold: this.sectionMatchThreshold,
             showStatusBarToggler: this.showStatusBarToggler,
             xmlFileName: this.xmlFileName,
-            sectionMatchThreshold: this.sectionMatchThreshold,
         };
     }
 

--- a/src/coverageservice.ts
+++ b/src/coverageservice.ts
@@ -52,6 +52,7 @@ export class CoverageService {
         this.topSectionFinder = new TopSectionFinder(
             this.outputChannel,
             this.eventReporter,
+            configStore,
         );
         this.renderer = new Renderer(
             configStore,

--- a/src/topSectionFinder.ts
+++ b/src/topSectionFinder.ts
@@ -3,8 +3,8 @@ import {extname} from "path";
 import {TextEditor} from "vscode";
 import {OutputChannel} from "vscode";
 import {findIntersect, normalizeFileName} from "./helpers";
-import {Reporter} from "./reporter";
 import {IConfigStore} from "./config";
+import {Reporter} from "./reporter";
 
 export class TopSectionFinder {
 
@@ -47,7 +47,7 @@ export class TopSectionFinder {
             // this score is the percent of the file path that is same as the intersect
             const score = (intersect.length / editorFile.length) * 100;
 
-            //score must be above configured threshold
+            // score must be above configured threshold
             if (score < this.configStore.sectionMatchThreshold) { return; }
             if (topSection.score > score) { return ; }
 

--- a/src/topSectionFinder.ts
+++ b/src/topSectionFinder.ts
@@ -46,7 +46,9 @@ export class TopSectionFinder {
             // create a score to judge top "performing" editor
             // this score is the percent of the file path that is same as the intersect
             const score = (intersect.length / editorFile.length) * 100;
-            if (this.configStore.matchNameExact && score < 100) { return; }
+
+            //score must be above configured threshold
+            if (score < this.configStore.sectionMatchThreshold) { return; }
             if (topSection.score > score) { return ; }
 
             // new top

--- a/src/topSectionFinder.ts
+++ b/src/topSectionFinder.ts
@@ -2,8 +2,8 @@ import {Section} from "lcov-parse";
 import {extname} from "path";
 import {TextEditor} from "vscode";
 import {OutputChannel} from "vscode";
-import {findIntersect, normalizeFileName} from "./helpers";
 import {IConfigStore} from "./config";
+import {findIntersect, normalizeFileName} from "./helpers";
 import {Reporter} from "./reporter";
 
 export class TopSectionFinder {

--- a/src/topSectionFinder.ts
+++ b/src/topSectionFinder.ts
@@ -4,18 +4,22 @@ import {TextEditor} from "vscode";
 import {OutputChannel} from "vscode";
 import {findIntersect, normalizeFileName} from "./helpers";
 import {Reporter} from "./reporter";
+import {IConfigStore} from "./config";
 
 export class TopSectionFinder {
 
     private outputChannel: OutputChannel;
     private eventReporter: Reporter;
+    private configStore: IConfigStore;
 
     constructor(
         outputChannel: OutputChannel,
         eventReporter: Reporter,
+        configStore: IConfigStore,
     ) {
         this.outputChannel = outputChannel;
         this.eventReporter = eventReporter;
+        this.configStore = configStore;
     }
 
     /**
@@ -42,6 +46,7 @@ export class TopSectionFinder {
             // create a score to judge top "performing" editor
             // this score is the percent of the file path that is same as the intersect
             const score = (intersect.length / editorFile.length) * 100;
+            if (this.configStore.matchNameExact && score < 100) { return; }
             if (topSection.score > score) { return ; }
 
             // new top

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -22,6 +22,7 @@ suite("Coverage Tests", function() {
         },
         showStatusBarToggler: true,
         xmlFileName: "test.xml",
+        sectionMatchThreshold: 50,
     };
 
     test("Constructor should setup properly @unit", function(done) {

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -20,9 +20,9 @@ suite("Coverage Tests", function() {
             key: "testKey3",
             dispose() {},
         },
+        sectionMatchThreshold: 50,
         showStatusBarToggler: true,
         xmlFileName: "test.xml",
-        sectionMatchThreshold: 50,
     };
 
     test("Constructor should setup properly @unit", function(done) {

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -20,9 +20,9 @@ suite("Renderer Tests", function() {
             key: "testKey3",
             dispose() {},
         },
+        sectionMatchThreshold: 50,
         showStatusBarToggler: true,
         xmlFileName: "test.xml",
-        sectionMatchThreshold: 50,
     };
 
     test("Constructor should setup properly @unit", function(done) {

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -22,6 +22,7 @@ suite("Renderer Tests", function() {
         },
         showStatusBarToggler: true,
         xmlFileName: "test.xml",
+        sectionMatchThreshold: 50,
     };
 
     test("Constructor should setup properly @unit", function(done) {

--- a/test/statusbartoggler.test.ts
+++ b/test/statusbartoggler.test.ts
@@ -21,6 +21,7 @@ suite("Status Bar Toggler Tests", function() {
         },
         showStatusBarToggler: false,
         xmlFileName: "test.xml",
+        sectionMatchThreshold: 50,
     };
 
     test("Should toggle showStatusBarToggler command and message @unit", function() {

--- a/test/statusbartoggler.test.ts
+++ b/test/statusbartoggler.test.ts
@@ -19,9 +19,9 @@ suite("Status Bar Toggler Tests", function() {
             key: "testKey3",
             dispose() {},
         },
+        sectionMatchThreshold: 50,
         showStatusBarToggler: false,
         xmlFileName: "test.xml",
-        sectionMatchThreshold: 50,
     };
 
     test("Should toggle showStatusBarToggler command and message @unit", function() {

--- a/test/topSectionFinder.test.ts
+++ b/test/topSectionFinder.test.ts
@@ -34,9 +34,9 @@ suite("TopSectionFinder Tests", function() {
             key: "testKey3",
             dispose() {},
         },
+        sectionMatchThreshold: 50,
         showStatusBarToggler: true,
         xmlFileName: "test.xml",
-        sectionMatchThreshold: 50,
     };
 
     test("Should not throw an error @unit", function(done) {

--- a/test/topSectionFinder.test.ts
+++ b/test/topSectionFinder.test.ts
@@ -20,6 +20,22 @@ suite("TopSectionFinder Tests", function() {
     };
 
     const fakeConfig = {
+        altSfCompare: false,
+        fullCoverageDecorationType: {
+            key: "testKey",
+            dispose() {},
+        },
+        lcovFileName: "test.ts",
+        noCoverageDecorationType: {
+            key: "testKey4",
+            dispose() {},
+        },
+        partialCoverageDecorationType: {
+            key: "testKey3",
+            dispose() {},
+        },
+        showStatusBarToggler: true,
+        xmlFileName: "test.xml",
         sectionMatchThreshold: 50,
     };
 

--- a/test/topSectionFinder.test.ts
+++ b/test/topSectionFinder.test.ts
@@ -19,10 +19,14 @@ suite("TopSectionFinder Tests", function() {
         sendEvent: () => {},
     };
 
+    const fakeConfig = {
+        sectionMatchThreshold: 50,
+    };
+
     test("Should not throw an error @unit", function(done) {
         const textEditor: TextEditor = {} as TextEditor;
         const sectionMap: Map<string, Section> = new Map<string, Section>();
-        const topSectionFinder: TopSectionFinder = new TopSectionFinder(fakeOutput, fakeReporter as any);
+        const topSectionFinder: TopSectionFinder = new TopSectionFinder(fakeOutput, fakeReporter as any, fakeConfig);
         topSectionFinder.findTopSectionForEditor(textEditor, sectionMap);
         return done();
     });


### PR DESCRIPTION
Added logic to show coverage only to files that match exactly (new configuration option matchNameExact)