### PR TITLE
convert relative paths from lcov output to absolute paths

### DIFF
--- a/src/files/coverageparser.ts
+++ b/src/files/coverageparser.ts
@@ -121,12 +121,9 @@ export class CoverageParser {
         }
 
         function findAbsolutePathFromTextDocumentsWhenRelativePath() {
-            
             if (!workspace.textDocuments) { return possiblePath; }
-            if (!possiblePath.startsWith('.')) { return possiblePath }
-            
+            if (!possiblePath.startsWith(".")) { return possiblePath; }
             const partialPath = possiblePath.substring(1);
-        
             // look through currently open documents for possible path
             const filePaths = workspace.textDocuments.map(
                 (document) => document.uri.fsPath,
@@ -135,13 +132,13 @@ export class CoverageParser {
             // find possible match to absolutely path of open document
             filePaths.forEach((filePath) => {
                 if (filePath.endsWith(partialPath)) {
-                    files.push(filePath)
+                    files.push(filePath);
                 }
-            })
+            });
             if (files.length === 1) {
-                return files[0]
+                return files[0];
             } else {
-                return possiblePath
+                return possiblePath;
             }
         }
 

--- a/src/files/coverageparser.ts
+++ b/src/files/coverageparser.ts
@@ -120,6 +120,31 @@ export class CoverageParser {
             return files[0];
         }
 
+        function findAbsolutePathFromTextDocumentsWhenRelativePath() {
+            
+            if (!workspace.textDocuments) { return possiblePath; }
+            if (!possiblePath.startsWith('.')) { return possiblePath }
+            
+            const partialPath = possiblePath.substring(1);
+        
+            // look through currently open documents for possible path
+            const filePaths = workspace.textDocuments.map(
+                (document) => document.uri.fsPath,
+            );
+            const files: string[] = [];
+            // find possible match to absolutely path of open document
+            filePaths.forEach((filePath) => {
+                if (filePath.endsWith(partialPath)) {
+                    files.push(filePath)
+                }
+            })
+            if (files.length === 1) {
+                return files[0]
+            } else {
+                return possiblePath
+            }
+        }
+
         switch (fileType) {
             case CoverageType.COBERTURA:
             case CoverageType.JACOCO:
@@ -132,6 +157,7 @@ export class CoverageParser {
                 }
                 break;
             default:
+                possiblePath = findAbsolutePathFromTextDocumentsWhenRelativePath();
                 break;
         }
         return possiblePath;


### PR DESCRIPTION
When an LCOV file contains paths relative to the project, the opened document will not be highlighted.

For example, transforming the below:
`SF:/home/ryanluker/dev/vscode-coverage-gutters/example/node/test.js`

to:
`SF:./example/node/test.js`

Will cause test.js to not be found, which results in coverage not being highlighted.

This addition attempts to search for absolute paths only when the provided path is relative, otherwise it will return the already known `possiblePath`. 

Instead of searching through the various workspace folder globs, this will inspect the currently open documents made available via `workspace.textDocuments`. 