### PR TITLE
Add coverage file names config and cleanup historical method

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,15 @@
           ],
           "description": "paths that will be ignored by the extension"
         },
+        "coverage-gutters.coverageFileNames": {
+          "type": "Array<string>",
+          "default": [
+            "lcov.info",
+            "cov.xml",
+            "jacoco.xml"
+          ],
+          "description": "Coverage file names for the extension to automatically look for"
+        },
         "coverage-gutters.customizable.status-bar-toggler-watchCoverageAndVisibleEditors-enabled": {
           "type": "boolean",
           "default": true,

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -8,8 +8,7 @@ import {InterfaceVscode} from "../wrappers/vscode";
 import {Reporter} from "./reporter";
 
 export interface IConfigStore {
-    lcovFileName: string;
-    xmlFileName: string;
+    coverageFileNames: string[];
     fullCoverageDecorationType: TextEditorDecorationType;
     partialCoverageDecorationType: TextEditorDecorationType;
     noCoverageDecorationType: TextEditorDecorationType;
@@ -22,8 +21,7 @@ export class Config {
     private context: ExtensionContext;
     private reporter: Reporter;
 
-    private lcovFileName: string;
-    private xmlFileName: string;
+    private coverageFileNames: string[];
     private fullCoverageDecorationType: TextEditorDecorationType;
     private partialCoverageDecorationType: TextEditorDecorationType;
     private noCoverageDecorationType: TextEditorDecorationType;
@@ -39,13 +37,12 @@ export class Config {
 
     public get(): IConfigStore {
         return {
+            coverageFileNames: this.coverageFileNames,
             fullCoverageDecorationType: this.fullCoverageDecorationType,
             ignoredPathGlobs: this.ignoredPaths,
-            lcovFileName: this.lcovFileName,
             noCoverageDecorationType: this.noCoverageDecorationType,
             partialCoverageDecorationType: this.partialCoverageDecorationType,
             showStatusBarToggler: this.showStatusBarToggler,
-            xmlFileName: this.xmlFileName,
         };
     }
 
@@ -64,8 +61,15 @@ export class Config {
         const rootConfig = this.vscode.getConfiguration("coverage-gutters");
 
         // Basic configurations
-        this.lcovFileName = rootConfig.get("lcovname") as string;
-        this.xmlFileName = rootConfig.get("xmlname") as string;
+        // TODO: remove lcovname and xmlname in 3.0.0 release
+        const lcovName = rootConfig.get("lcovname") as string;
+        const xmlName = rootConfig.get("xmlname") as string;
+        this.coverageFileNames = rootConfig.get("coverageFileNames") as string[];
+        this.coverageFileNames.push(lcovName, xmlName);
+
+        // Make fileNames unique
+        this.coverageFileNames = [...new Set(this.coverageFileNames)];
+
         const STATUS_BAR_TOGGLER = "status-bar-toggler-watchCoverageAndVisibleEditors-enabled";
         this.showStatusBarToggler = rootCustomConfig.get(STATUS_BAR_TOGGLER) as boolean;
 

--- a/src/files/filesloader.ts
+++ b/src/files/filesloader.ts
@@ -14,10 +14,7 @@ export class FilesLoader {
      * Finds all coverages files by xml and lcov and returns them
      */
     public async findCoverageFiles(): Promise<Set<string>> {
-        const fileNames = [
-            this.configStore.lcovFileName,
-            this.configStore.xmlFileName,
-        ];
+        const fileNames = this.configStore.coverageFileNames;
         const files = await this.findCoverageInWorkspace(fileNames);
         if (!files.size) { throw new Error("Could not find a Coverage file!"); }
         return files;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -6,6 +6,9 @@ suite("Extension Tests", function() {
     this.timeout(25000);
 
     test("Run display coverage on node test file @integration", async () => {
+        // Wait for extension to load
+        await sleep(2000);
+
         const extension = await vscode.extensions.getExtension("ryanluker.vscode-coverage-gutters");
         if (!extension) {
             throw new Error("Could not load extension");
@@ -14,7 +17,7 @@ suite("Extension Tests", function() {
         const emptyLines = extension.exports.emptyLastCoverage;
         const testCoverage = await vscode.workspace.findFiles("**/test-coverage.js", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
-        const testEditor = await vscode.window.showTextDocument(testDocument);
+        await vscode.window.showTextDocument(testDocument);
         await vscode.commands.executeCommand("extension.displayCoverage");
 
         // Wait for decorations to load
@@ -29,6 +32,9 @@ suite("Extension Tests", function() {
     });
 
     test("Run display coverage on python test file @integration", async () => {
+        // Wait for extension to load
+        await sleep(2000);
+
         const extension = await vscode.extensions.getExtension("ryanluker.vscode-coverage-gutters");
         if (!extension) {
             throw new Error("Could not load extension");
@@ -37,7 +43,7 @@ suite("Extension Tests", function() {
         const emptyLines = extension.exports.emptyLastCoverage;
         const testCoverage = await vscode.workspace.findFiles("**/bar/a.py", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
-        const testEditor = await vscode.window.showTextDocument(testDocument);
+        await vscode.window.showTextDocument(testDocument);
         await vscode.commands.executeCommand("extension.displayCoverage");
 
         // Wait for decorations to load
@@ -51,6 +57,9 @@ suite("Extension Tests", function() {
     });
 
     test("Run display coverage on php test file number 1 @integration", async () => {
+        // Wait for extension to load
+        await sleep(2000);
+
         const extension = await vscode.extensions.getExtension("ryanluker.vscode-coverage-gutters");
         if (!extension) {
             throw new Error("Could not load extension");
@@ -59,7 +68,7 @@ suite("Extension Tests", function() {
         const emptyLines = extension.exports.emptyLastCoverage;
         const testCoverage = await vscode.workspace.findFiles("**/main.php", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
-        const testEditor = await vscode.window.showTextDocument(testDocument);
+        await vscode.window.showTextDocument(testDocument);
         await vscode.commands.executeCommand("extension.displayCoverage");
 
         // Wait for decorations to load
@@ -73,6 +82,9 @@ suite("Extension Tests", function() {
     });
 
     test("Run display coverage on php test file number 2 @integration", async () => {
+        // Wait for extension to load
+        await sleep(2000);
+
         const extension = await vscode.extensions.getExtension("ryanluker.vscode-coverage-gutters");
         if (!extension) {
             throw new Error("Could not load extension");
@@ -81,7 +93,7 @@ suite("Extension Tests", function() {
         const emptyLines = extension.exports.emptyLastCoverage;
         const testCoverage = await vscode.workspace.findFiles("**/main2.php", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
-        const testEditor = await vscode.window.showTextDocument(testDocument);
+        await vscode.window.showTextDocument(testDocument);
         await vscode.commands.executeCommand("extension.displayCoverage");
 
         // Wait for decorations to load
@@ -95,6 +107,9 @@ suite("Extension Tests", function() {
     });
 
     test("Run display coverage on java test file @integration", async () => {
+        // Wait for extension to load
+        await sleep(2000);
+
         const extension = await vscode.extensions.getExtension("ryanluker.vscode-coverage-gutters");
         if (!extension) {
             throw new Error("Could not load extension");
@@ -103,7 +118,7 @@ suite("Extension Tests", function() {
         const emptyLines = extension.exports.emptyLastCoverage;
         const testCoverage = await vscode.workspace.findFiles("**/mycompany/app/App.java", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
-        const testEditor = await vscode.window.showTextDocument(testDocument);
+        await vscode.window.showTextDocument(testDocument);
         await vscode.commands.executeCommand("extension.displayCoverage");
 
         // Wait for decorations to load

--- a/test/extension/config.test.ts
+++ b/test/extension/config.test.ts
@@ -14,10 +14,20 @@ suite("Config Tests", function() {
 
         getConfiguration: () => {
             return {
-                get: () => "123",
+                coverageFileNames: ["test.xml", "lcov.info"],
+                get: (key) => {
+                    if (key === "coverageFileNames") {
+                        return ["test.xml", "lcov.info"];
+                    } else if (key === "lcovname") {
+                        return "lcov.info";
+                    }
+                    return "123";
+                },
+                lcovname: "lcov.info",
                 test1: "test1",
                 test2: "test2",
                 test3: "test3",
+                xmlname: "name.xml",
             };
         },
     };
@@ -44,6 +54,13 @@ suite("Config Tests", function() {
         const config = new Config(fakeVscode, fakeContext, fakeReport);
         const store = config.get();
         assert.notEqual(store.coverageFileNames, null);
+    });
+
+    test("Can get coverage file names @unit", function() {
+        const config = new Config(fakeVscode, fakeContext, fakeReport);
+        const store = config.get();
+        // Check that unique file names is being applied
+        assert.equal(store.coverageFileNames.length, 3);
     });
 
     test("Should remove gutter icons if path is blank, allows breakpoint usage @unit", function() {

--- a/test/extension/config.test.ts
+++ b/test/extension/config.test.ts
@@ -43,7 +43,7 @@ suite("Config Tests", function() {
     test("Can get configStore after initialization @unit", function() {
         const config = new Config(fakeVscode, fakeContext, fakeReport);
         const store = config.get();
-        assert.notEqual(store.lcovFileName, null);
+        assert.notEqual(store.coverageFileNames, null);
     });
 
     test("Should remove gutter icons if path is blank, allows breakpoint usage @unit", function() {

--- a/test/fakeConfig.test.ts
+++ b/test/fakeConfig.test.ts
@@ -1,12 +1,12 @@
 import { IConfigStore } from "../src/extension/config";
 
 export const fakeConfig: IConfigStore = {
+    coverageFileNames: ["test.ts", "test.xml"],
     fullCoverageDecorationType: {
         key: "testKey",
         dispose() { },
     },
     ignoredPathGlobs: ["test/*"],
-    lcovFileName: "test.ts",
     noCoverageDecorationType: {
         key: "testKey4",
         dispose() { },
@@ -16,5 +16,4 @@ export const fakeConfig: IConfigStore = {
         dispose() { },
     },
     showStatusBarToggler: true,
-    xmlFileName: "test.xml",
 };


### PR DESCRIPTION
## Issue:
closes #175 
related PR #176 

## Changes:
- [x] added coverageFileNames to the extension config options
- [x] deprecated old xmlname and lcovname (left them in til 3.0.0) but still load them
- [x] add new config tests for the "unique" file names
