### PR TITLE
Ignore empty coverage filenames

### DIFF
--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -66,6 +66,7 @@ export class Config {
         const xmlName = rootConfig.get("xmlname") as string;
         this.coverageFileNames = rootConfig.get("coverageFileNames") as string[];
         this.coverageFileNames.push(lcovName, xmlName);
+        this.coverageFileNames = this.coverageFileNames.filter((name) => !!name.trim());
 
         // Make fileNames unique
         this.coverageFileNames = [...new Set(this.coverageFileNames)];


### PR DESCRIPTION
Seems you just can't trust me to configure a vscode plugin I keep putting in dodgy config that breaks my coverage. I accidentally cleared the xml config filename which resulted in the [fileloader](https://github.com/ryanluker/vscode-coverage-gutters/blob/a3070176a5472766de998b5053a4d9197cf56a10/src/files/filesloader.ts#L48) attempting to load every file in my workspace resulting in this error:
```
[1543244667227][coverageservice]: INITIALIZING
[1543244667527][coverageservice]: LOADING
[1543244672779][coverageservice]: Loading 1237 file(s)
[1543244672782][gutters]: Error EISDIR: illegal operation on a directory, read
[1543244672782][gutters]: Stacktrace Error: EISDIR: illegal operation on a directory, read
[1543244672783][coverageservice]: RENDERING
[1543244672783][coverageservice]: READY
```

How do you feel about adding a log message for each coverage file processed? This might help the user see which files are loaded and maybe determine if they have messed up the config.