### PR TITLE
Use proper latest version of cobertura parse

### DIFF
--- a/@types/cobertura-parse/index.d.ts
+++ b/@types/cobertura-parse/index.d.ts
@@ -1,5 +1,9 @@
 declare namespace parse {
-    function parseContent(str: string, cb: (err: Error, data: Array<Section>) => void, absPath: string): void
+    function parseContent(
+        str: string,
+        cb: (err: Error, data: Array<Section>) => void,
+        absPath: boolean
+    ): void
 
     interface LineDetail {
         hit: number,

--- a/@types/jacoco-parse/index.d.ts
+++ b/@types/jacoco-parse/index.d.ts
@@ -1,5 +1,8 @@
 declare namespace parse {
-    function parseContent(str: string, cb: (err: Error, data: Array<Section>) => void): void
+    function parseContent(
+        str: string,
+        cb: (err: Error, data: Array<Section>) => void
+    ): void
 
     interface LineDetail {
         hit: number,

--- a/package-lock.json
+++ b/package-lock.json
@@ -437,9 +437,8 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "cobertura-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/cobertura-parse/-/cobertura-parse-1.0.5.tgz",
-      "integrity": "sha512-uYJfkGhzw1wibe/8jqqHmSaPNWFguzq/IlSj83u3cSnZho/lUnfj0mLTmZGmB3AiKCOTYr22TYwpR1sXy2JEkg==",
+      "version": "github:vokal/cobertura-parse#53109a677c995f5d2e90acd0fcd0b0788a6ec061",
+      "from": "github:vokal/cobertura-parse#53109a6",
       "requires": {
         "mocha": "5.0.5",
         "xml2js": "0.4.19"
@@ -457,7 +456,7 @@
         },
         "mocha": {
           "version": "5.0.5",
-          "resolved": "http://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
           "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
           "requires": {
             "browser-stdout": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
   },
   "dependencies": {
     "@cvrg-report/clover-json": "0.3.0",
-    "cobertura-parse": "1.0.5",
+    "cobertura-parse": "github:vokal/cobertura-parse#53109a6",
     "glob": "7.1.2",
     "jacoco-parse": "2.0.1",
     "lcov-parse": "1.0.0",

--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -57,7 +57,6 @@ export class CoverageService {
             this.sectionFinder,
         );
         this.coverageParser = new CoverageParser(
-            configStore,
             this.outputChannel,
             this.eventReporter,
         );


### PR DESCRIPTION
Related Issue: #203 
## Work
- [x] add latest version of cobertura parse
- [x] use new absPath functionality
- [x] cleanup typings and method signatures