### PR TITLE
Don't crash if we find empty lcov.info (#150)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/src/files/coveragefile.ts
+++ b/src/files/coveragefile.ts
@@ -1,4 +1,5 @@
 export enum CoverageType {
+    NONE,
     LCOV,
     CLOVER,
     COBERTURA,
@@ -19,7 +20,7 @@ export class CoverageFile {
      * @param file file to detect type information
      */
     private setFileType(file: string) {
-        let possibleType = CoverageType.LCOV;
+        let possibleType = CoverageType.NONE;
         if (
             file.includes("<?xml") &&
             file.includes("<coverage") &&
@@ -30,6 +31,8 @@ export class CoverageFile {
             possibleType = CoverageType.JACOCO;
         } else if (file.includes("<?xml")) {
             possibleType = CoverageType.COBERTURA;
+        } else if (file !== "") {
+            possibleType = CoverageType.LCOV;
         }
         this.type = possibleType;
     }

--- a/test/files/coveragefile.test.ts
+++ b/test/files/coveragefile.test.ts
@@ -19,4 +19,9 @@ suite("Coverage File Tests", function() {
         const coverageFile = new CoverageFile(fakeLcovInfo);
         assert.equal(coverageFile.type, CoverageType.LCOV);
     });
+
+    test("Ignores empty file (#150)", function() {
+        const coverageFile = new CoverageFile("");
+        assert.equal(coverageFile.type, CoverageType.NONE);
+    });
 });


### PR DESCRIPTION
Sometimes we may encounter an empty `lcov.info` file. Since we know
that an empty file can't contain valid coverage data, we simply
ignore it rather than unsuccessfully trying to load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ryanluker/vscode-coverage-gutters/215)
<!-- Reviewable:end -->
