### PR TITLE
Add config option for context menu commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,11 @@
           "type": "boolean",
           "default": true,
           "description": "enable or disable the status bar item"
+        },
+        "coverage-gutters.customizable.context-menu": {
+          "type": "boolean",
+          "default": true,
+          "description": "enable or disable quick commands in the context menu"
         }
       }
     },
@@ -197,22 +202,27 @@
     "menus": {
       "editor/context": [
         {
+          "when": "config.coverage-gutters.customizable.context-menu",
           "command": "extension.previewCoverageReport",
           "group": "Coverage-Gutters@1"
         },
         {
+          "when": "config.coverage-gutters.customizable.context-menu",
           "command": "extension.displayCoverage",
           "group": "Coverage-Gutters@2"
         },
         {
+          "when": "config.coverage-gutters.customizable.context-menu",
           "command": "extension.watchCoverageAndVisibleEditors",
           "group": "Coverage-Gutters@3"
         },
         {
+          "when": "config.coverage-gutters.customizable.context-menu",
           "command": "extension.removeWatch",
           "group": "Coverage-Gutters@4"
         },
         {
+          "when": "config.coverage-gutters.customizable.context-menu",
           "command": "extension.removeCoverage",
           "group": "Coverage-Gutters@5"
         }


### PR DESCRIPTION
There used to be options for this, not sure why it doesn't work anymore. This is the new implementation. 

It used to be several different config flags, but I combined it into one. I figured people would either want all of it or none. It also reduces clutter from too many options. However I noticed you had very fine-grain control for the existing options. Opinions?

Side note, it kind of bothers me that 2 of the config descriptions are Capitalized while the rest are not :(

See links below for details.
https://code.visualstudio.com/api/references/contribution-points#contributes.menus
https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts

Fixes #216. 