### PR TITLE
Add manual coverage path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Build Status](https://dev.azure.com/ryanluker/vscode-coverage-gutters/_apis/build/status/vscode-coverage-gutters-CI)](https://dev.azure.com/ryanluker/vscode-coverage-gutters/_build/latest?definitionId=1)
 
 ## New Features in 2.4.0
-- New remote path resolve feature that helps swap remote paths with local ones (EG ['/var/www/', '/home/project/']). See https://github.com/ryanluker/vscode-coverage-gutters/issues/201 for more info.
+- New remote path resolve feature that helps swap remote paths with local ones (EG ['/var/www/', '/home/project/']). See https://github.com/ryanluker/vscode-coverage-gutters/issues/201.
+- Manually define your coverage file(s) instead of the project search option. See https://github.com/ryanluker/vscode-coverage-gutters/issues/178.
 - Turn off context menu options with a settings.json change (Thanks to https://github.com/wenbei999 for this!)
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -129,6 +129,11 @@
           "default": [],
           "description": "helps with coverage generated outside the local file system by swapping fragments of remote paths with local ones (EG ['/var/www/', '/home/project/']). See https://github.com/ryanluker/vscode-coverage-gutters/issues/201 for more info."
         },
+        "coverage-gutters.manualCoverageFilePaths": {
+          "type": "array",
+          "default": [],
+          "description": "take manual control over the absolute path to your coverage file(s)"
+        },
         "coverage-gutters.coverageFileNames": {
           "type": "array",
           "default": [

--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -136,12 +136,12 @@ export class CoverageService {
     private listenToFileSystem() {
         // If the user has defined manual coverage files to do continue, as the files
         // defined could be outside the workspace folders and not "watchable".
-        if (this.configStore.manualCoverageFilePaths.length) return;
+        if (this.configStore.manualCoverageFilePaths.length) { return; }
 
         const fileNames = this.configStore.coverageFileNames.toString();
         // Creates a BlobPattern for all coverage files.
         // EX: `**/{cov.xml, lcov.info}`
-        const blobPattern = `**/{${fileNames}}`
+        const blobPattern = `**/{${fileNames}}`;
         this.coverageWatcher = workspace.createFileSystemWatcher(blobPattern);
         this.coverageWatcher.onDidChange(this.loadCacheAndRender.bind(this));
         this.coverageWatcher.onDidCreate(this.loadCacheAndRender.bind(this));

--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -134,12 +134,15 @@ export class CoverageService {
     }
 
     private listenToFileSystem() {
+        // If the user has defined manual coverage files to do continue, as the files
+        // defined could be outside the workspace folders and not "watchable".
+        if (this.configStore.manualCoverageFilePaths.length) return;
+
         const fileNames = this.configStore.coverageFileNames.toString();
         // Creates a BlobPattern for all coverage files.
         // EX: `**/{cov.xml, lcov.info}`
-        this.coverageWatcher = workspace.createFileSystemWatcher(
-            `**/{${fileNames}}`,
-        );
+        const blobPattern = `**/{${fileNames}}`
+        this.coverageWatcher = workspace.createFileSystemWatcher(blobPattern);
         this.coverageWatcher.onDidChange(this.loadCacheAndRender.bind(this));
         this.coverageWatcher.onDidCreate(this.loadCacheAndRender.bind(this));
         this.coverageWatcher.onDidDelete(this.loadCacheAndRender.bind(this));

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -148,7 +148,7 @@ export class Config {
         this.reporter.sendEvent(
             "config",
             "hasManualCoverageFilePaths",
-            hasManualCoverageFilePaths.toString()
+            hasManualCoverageFilePaths.toString(),
         );
     }
 

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -18,6 +18,7 @@ export class Config {
     public showStatusBarToggler: boolean;
     public ignoredPathGlobs: string;
     public remotePathResolve: string[];
+    public manualCoverageFilePaths: string[];
 
     private context: ExtensionContext;
     private reporter: Reporter;
@@ -140,6 +141,15 @@ export class Config {
         this.remotePathResolve = rootConfig.get("remotePathResolve") as string[];
         const hasRemotePathResolve = !!this.remotePathResolve.length;
         this.reporter.sendEvent("config", "remotePathResolve", hasRemotePathResolve.toString());
+
+        // Add the manual coverage file path(s) if present
+        this.manualCoverageFilePaths = rootConfig.get("manualCoverageFilePaths") as string[];
+        const hasManualCoverageFilePaths = !!this.manualCoverageFilePaths.length;
+        this.reporter.sendEvent(
+            "config",
+            "hasManualCoverageFilePaths",
+            hasManualCoverageFilePaths.toString()
+        );
     }
 
     /**

--- a/src/files/filesloader.ts
+++ b/src/files/filesloader.ts
@@ -12,12 +12,18 @@ export class FilesLoader {
 
     /**
      * Finds all coverages files by xml and lcov and returns them
+     * Note: Includes developer override via "manualCoverageFilePaths"
      */
     public async findCoverageFiles(): Promise<Set<string>> {
-        const fileNames = this.configStore.coverageFileNames;
-        const files = await this.findCoverageInWorkspace(fileNames);
-        if (!files.size) { throw new Error("Could not find a Coverage file!"); }
-        return files;
+        // Developers can manually define their absolute coverage paths
+        if (this.configStore.manualCoverageFilePaths.length) {
+            return new Set(this.configStore.manualCoverageFilePaths);
+        } else {
+            const fileNames = this.configStore.coverageFileNames;
+            const files = await this.findCoverageInWorkspace(fileNames);
+            if (!files.size) { throw new Error("Could not find a Coverage file!"); }
+            return files;
+        }
     }
 
     /**

--- a/test/files/filesloader.test.ts
+++ b/test/files/filesloader.test.ts
@@ -37,4 +37,12 @@ suite("FilesLoader Tests", function() {
             Error("Could not find a Coverage file!"),
         );
     });
+
+    test("findCoverageFiles returns manual coverage paths if set @unit", async function() {
+        const coverageFiles = ["test.js", "test2.js"];
+        fakeConfig.manualCoverageFilePaths = coverageFiles;
+        const filesLoader = new FilesLoader(fakeConfig);
+        const files = await filesLoader.findCoverageFiles();
+        assert.deepStrictEqual(new Set(coverageFiles), files);
+    });
 });

--- a/test/mocks/fakeConfig.ts
+++ b/test/mocks/fakeConfig.ts
@@ -5,6 +5,7 @@ export const fakeConfig: any = {
         dispose() { },
     },
     ignoredPathGlobs: "test/*",
+    manualCoverageFilePaths: [],
     noCoverageDecorationType: {
         key: "testKey4",
         dispose() { },


### PR DESCRIPTION
Related Issue: #178 

### Work
- [x] add manual coverage option
- [x] add tests to cover usage in the `findCoverageFiles`
- [x] manually test locally