### PR TITLE
Refine when github actions are fired

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: vscode-coverage-gutters-ci
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 jobs:
   build:
     strategy:


### PR DESCRIPTION
### Description
**Related Issue**: #225 
Currently github actions do not fire on forked repositories. To fix this we need to simply add the `pull_request` event and a specific push one for only master.
https://help.github.com/en/articles/events-that-trigger-workflows#pull-request-events-for-forked-repositories

### Work
- [x] refine github action triggers