### PR TITLE
extension was meant to be extension name.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -736,13 +736,24 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        }
       }
     },
     "inflight": {

--- a/package.json
+++ b/package.json
@@ -163,49 +163,49 @@
     },
     "commands": [
       {
-        "command": "extension.previewCoverageReport",
+        "command": "coverage-gutters.previewCoverageReport",
         "title": "Coverage Gutters: Preview Coverage Report"
       },
       {
-        "command": "extension.displayCoverage",
+        "command": "coverage-gutters.displayCoverage",
         "title": "Coverage Gutters: Display Coverage"
       },
       {
-        "command": "extension.watchCoverageAndVisibleEditors",
+        "command": "coverage-gutters.watchCoverageAndVisibleEditors",
         "title": "Coverage Gutters: Watch"
       },
       {
-        "command": "extension.removeWatch",
+        "command": "coverage-gutters.removeWatch",
         "title": "Coverage Gutters: Remove Watch"
       },
       {
-        "command": "extension.removeCoverage",
+        "command": "coverage-gutters.removeCoverage",
         "title": "Coverage Gutters: Remove Coverage"
       }
     ],
     "keybindings": [
       {
-        "command": "extension.previewCoverageReport",
+        "command": "coverage-gutters.previewCoverageReport",
         "key": "ctrl+shift+6",
         "mac": "shift+cmd+6"
       },
       {
-        "command": "extension.displayCoverage",
+        "command": "coverage-gutters.displayCoverage",
         "key": "ctrl+shift+7",
         "mac": "shift+cmd+7"
       },
       {
-        "command": "extension.watchCoverageAndVisibleEditors",
+        "command": "coverage-gutters.watchCoverageAndVisibleEditors",
         "key": "ctrl+shift+8",
         "mac": "shift+cmd+8"
       },
       {
-        "command": "extension.removeWatch",
+        "command": "coverage-gutters.removeWatch",
         "key": "ctrl+shift+9",
         "mac": "shift+cmd+9"
       },
       {
-        "command": "extension.removeCoverage",
+        "command": "coverage-gutters.removeCoverage",
         "key": "ctrl+shift+0",
         "mac": "shift+cmd+0"
       }
@@ -214,27 +214,27 @@
       "editor/context": [
         {
           "when": "config.coverage-gutters.customizable.context-menu",
-          "command": "extension.previewCoverageReport",
+          "command": "coverage-gutters.previewCoverageReport",
           "group": "Coverage-Gutters@1"
         },
         {
           "when": "config.coverage-gutters.customizable.context-menu",
-          "command": "extension.displayCoverage",
+          "command": "coverage-gutters.displayCoverage",
           "group": "Coverage-Gutters@2"
         },
         {
           "when": "config.coverage-gutters.customizable.context-menu",
-          "command": "extension.watchCoverageAndVisibleEditors",
+          "command": "coverage-gutters.watchCoverageAndVisibleEditors",
           "group": "Coverage-Gutters@3"
         },
         {
           "when": "config.coverage-gutters.customizable.context-menu",
-          "command": "extension.removeWatch",
+          "command": "coverage-gutters.removeWatch",
           "group": "Coverage-Gutters@4"
         },
         {
           "when": "config.coverage-gutters.customizable.context-menu",
-          "command": "extension.removeCoverage",
+          "command": "coverage-gutters.removeCoverage",
           "group": "Coverage-Gutters@5"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,10 @@
 import * as vscode from "vscode";
-import {Coverage} from "./coverage-system/coverage";
-import {Config} from "./extension/config";
-import {emptyLastCoverage, getLastCoverageLines} from "./extension/exportsapi";
-import {Gutters} from "./extension/gutters";
-import {Reporter} from "./extension/reporter";
-import {StatusBarToggler} from "./extension/statusbartoggler";
+import { Coverage } from "./coverage-system/coverage";
+import { Config } from "./extension/config";
+import { emptyLastCoverage, getLastCoverageLines } from "./extension/exportsapi";
+import { Gutters } from "./extension/gutters";
+import { Reporter } from "./extension/reporter";
+import { StatusBarToggler } from "./extension/statusbartoggler";
 
 export function activate(context: vscode.ExtensionContext) {
     const enableMetrics = vscode.workspace.getConfiguration("telemetry").get("enableTelemetry") as boolean;
@@ -22,23 +22,23 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     const previewCoverageReport = vscode.commands.registerCommand(
-        "extension.previewCoverageReport",
+        "coverage-gutters.previewCoverageReport",
         gutters.previewCoverageReport.bind(gutters),
     );
     const display = vscode.commands.registerCommand(
-        "extension.displayCoverage",
+        "coverage-gutters.displayCoverage",
         gutters.displayCoverageForActiveFile.bind(gutters),
     );
     const watch = vscode.commands.registerCommand(
-        "extension.watchCoverageAndVisibleEditors",
+        "coverage-gutters.watchCoverageAndVisibleEditors",
         gutters.watchCoverageAndVisibleEditors.bind(gutters),
     );
     const removeWatch = vscode.commands.registerCommand(
-        "extension.removeWatch",
+        "coverage-gutters.removeWatch",
         gutters.removeWatch.bind(gutters),
     );
     const remove = vscode.commands.registerCommand(
-        "extension.removeCoverage",
+        "coverage-gutters.removeCoverage",
         gutters.removeCoverageForActiveFile.bind(gutters),
     );
 

--- a/src/extension/statusbartoggler.ts
+++ b/src/extension/statusbartoggler.ts
@@ -2,8 +2,8 @@ import { Disposable, StatusBarItem, window } from "vscode";
 import { Config } from "./config";
 
 export class StatusBarToggler implements Disposable {
-    private static readonly watchCommand = "extension.watchCoverageAndVisibleEditors";
-    private static readonly removeCommand = "extension.removeWatch";
+    private static readonly watchCommand = "coverage-gutters.watchCoverageAndVisibleEditors";
+    private static readonly removeCommand = "coverage-gutters.removeWatch";
     private static readonly watchText = "$(list-ordered) Watch";
     private static readonly removeText = "$(list-ordered) Remove Watch";
     private static readonly toolTip = "Coverage Gutters: Watch and Remove Helper";

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,9 +1,9 @@
 import * as assert from "assert";
 import { exec } from "child_process";
 import * as vscode from "vscode";
-import {ICoverageLines} from "../src/coverage-system/renderer";
+import { ICoverageLines } from "../src/coverage-system/renderer";
 
-suite("Extension Tests", function() {
+suite("Extension Tests", function () {
     this.timeout(25000);
 
     test("Preview the coverage report in a new webview tab @integration", async () => {
@@ -16,7 +16,7 @@ suite("Extension Tests", function() {
             throw new Error("Could not load extension");
         }
 
-        await vscode.commands.executeCommand("extension.previewCoverageReport");
+        await vscode.commands.executeCommand("coverage-gutters.previewCoverageReport");
         // Look to see if the webview is open and showing preview coverage
         await waitForExtension(2000);
         const reportView = vscode.workspace.textDocuments[1];
@@ -34,7 +34,7 @@ suite("Extension Tests", function() {
         const testCoverage = await vscode.workspace.findFiles("**/remote-test-coverage.js", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
         await vscode.window.showTextDocument(testDocument);
-        await vscode.commands.executeCommand("extension.displayCoverage");
+        await vscode.commands.executeCommand("coverage-gutters.displayCoverage");
 
         await checkCoverage(() => {
             // Look for exact coverage on the file
@@ -58,7 +58,7 @@ suite("Extension Tests", function() {
         const testCoverage = await vscode.workspace.findFiles("**/test-coverage.js", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
         await vscode.window.showTextDocument(testDocument);
-        await vscode.commands.executeCommand("extension.displayCoverage");
+        await vscode.commands.executeCommand("coverage-gutters.displayCoverage");
 
         await checkCoverage(() => {
             // Look for exact coverage on the file
@@ -81,7 +81,7 @@ suite("Extension Tests", function() {
         const testCoverage = await vscode.workspace.findFiles("**/bar/a.py", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
         await vscode.window.showTextDocument(testDocument);
-        await vscode.commands.executeCommand("extension.displayCoverage");
+        await vscode.commands.executeCommand("coverage-gutters.displayCoverage");
 
         await checkCoverage(() => {
             // Look for exact coverage on the file
@@ -103,7 +103,7 @@ suite("Extension Tests", function() {
         const testCoverage = await vscode.workspace.findFiles("**/main.php", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
         await vscode.window.showTextDocument(testDocument);
-        await vscode.commands.executeCommand("extension.displayCoverage");
+        await vscode.commands.executeCommand("coverage-gutters.displayCoverage");
 
         await checkCoverage(() => {
             // Look for exact coverage on the file
@@ -125,7 +125,7 @@ suite("Extension Tests", function() {
         const testCoverage = await vscode.workspace.findFiles("**/main2.php", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
         await vscode.window.showTextDocument(testDocument);
-        await vscode.commands.executeCommand("extension.displayCoverage");
+        await vscode.commands.executeCommand("coverage-gutters.displayCoverage");
 
         await checkCoverage(() => {
             // Look for exact coverage on the file
@@ -147,7 +147,7 @@ suite("Extension Tests", function() {
         const testCoverage = await vscode.workspace.findFiles("**/mycompany/app/App.java", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
         await vscode.window.showTextDocument(testDocument);
-        await vscode.commands.executeCommand("extension.displayCoverage");
+        await vscode.commands.executeCommand("coverage-gutters.displayCoverage");
 
         await checkCoverage(() => {
             // Look for exact coverage on the file
@@ -178,7 +178,7 @@ suite("Extension Tests", function() {
         await exec("cp -r node node7");
 
         await vscode.window.showTextDocument(testDocument);
-        await vscode.commands.executeCommand("extension.displayCoverage");
+        await vscode.commands.executeCommand("coverage-gutters.displayCoverage");
 
         await checkCoverage(() => {
             // Look for exact coverage on the file
@@ -200,7 +200,7 @@ suite("Extension Tests", function() {
         const getCachedLines = extension.exports.getLastCoverageLines;
 
         // Look at javascript file and assert coverage
-        await vscode.commands.executeCommand("extension.watchCoverageAndVisibleEditors");
+        await vscode.commands.executeCommand("coverage-gutters.watchCoverageAndVisibleEditors");
         const testJSCoverage = await vscode.workspace.findFiles("**/test-coverage.js", "**/node_modules/**");
         const testJSDocument = await vscode.workspace.openTextDocument(testJSCoverage[0]);
         await vscode.window.showTextDocument(testJSDocument);
@@ -219,7 +219,7 @@ suite("Extension Tests", function() {
         const testJavaCoverage = await vscode.workspace.findFiles("**/mycompany/app/App.java", "**/node_modules/**");
         const testJavaDocument = await vscode.workspace.openTextDocument(testJavaCoverage[0]);
         await vscode.window.showTextDocument(testJavaDocument);
-        await vscode.commands.executeCommand("extension.displayCoverage");
+        await vscode.commands.executeCommand("coverage-gutters.displayCoverage");
         await waitForExtension(2000);
 
         await checkCoverage(() => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -3,7 +3,7 @@ import { exec } from "child_process";
 import * as vscode from "vscode";
 import { ICoverageLines } from "../src/coverage-system/renderer";
 
-suite("Extension Tests", function () {
+suite("Extension Tests", function() {
     this.timeout(25000);
 
     test("Preview the coverage report in a new webview tab @integration", async () => {


### PR DESCRIPTION
At the moment the commands are under a namespace called 'extension'. That's a little confusing for anyone trying to call those commands as we'd guess vscode-coverage-gutters or coverage-gutters (I'm not entirely sure which is the most correct, but either is better than having them prefixed extension.

Figured I'd raise it as a PR rather than an issue.