### PR TITLE
Make manualCoverageFilePaths watchable

### DIFF
--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -128,14 +128,19 @@ export class CoverageService {
     }
 
     private listenToFileSystem() {
-        // If the user has defined manual coverage files to do continue, as the files
-        // defined could be outside the workspace folders and not "watchable".
-        if (this.configStore.manualCoverageFilePaths.length) { return; }
+        let blobPattern;
+        // Monitor only manual coverage files if the user has defined them
+        if (this.configStore.manualCoverageFilePaths.length) {
+            // Paths outside of workspace folders will not be watchable,
+            // but those that are inside workspace will still work as expected
+            blobPattern = `{${this.configStore.manualCoverageFilePaths}}`;
+        } else {
+            const fileNames = this.configStore.coverageFileNames.toString();
+            // Creates a BlobPattern for all coverage files.
+            // EX: `**/{cov.xml, lcov.info}`
+            blobPattern = `**/{${fileNames}}`;
+        }
 
-        const fileNames = this.configStore.coverageFileNames.toString();
-        // Creates a BlobPattern for all coverage files.
-        // EX: `**/{cov.xml, lcov.info}`
-        const blobPattern = `**/{${fileNames}}`;
         this.coverageWatcher = workspace.createFileSystemWatcher(blobPattern);
         this.coverageWatcher.onDidChange(this.loadCacheAndRender.bind(this));
         this.coverageWatcher.onDidCreate(this.loadCacheAndRender.bind(this));

--- a/test/coverage-system/coverageservice.test.ts
+++ b/test/coverage-system/coverageservice.test.ts
@@ -13,7 +13,7 @@ suite("CoverageService Tests", function() {
         (workspace as any).createFileSystemWatcher = createFileSystemWatcher;
     });
 
-    test("Should listen for all paths specified in manualCoverageFilePaths @unit", function(done) {
+    test("Should listen for all paths specified in manualCoverageFilePaths @unit", function() {
         const config: any = {
             manualCoverageFilePaths: [
                 "/path1",

--- a/test/coverage-system/coverageservice.test.ts
+++ b/test/coverage-system/coverageservice.test.ts
@@ -1,0 +1,38 @@
+import * as assert from "assert";
+import {OutputChannel, workspace} from "vscode";
+
+import {CoverageService} from "../../src/coverage-system/coverageservice";
+
+const mockOutputChannel = {appendLine: (x) => {}} as OutputChannel;
+
+// Original functions
+const createFileSystemWatcher = workspace.createFileSystemWatcher;
+
+suite("CoverageService Tests", function() {
+    teardown(function() {
+        (workspace as any).createFileSystemWatcher = createFileSystemWatcher;
+    });
+
+    test("Should listen for all paths specified in manualCoverageFilePaths @unit", function(done) {
+        const config: any = {
+            manualCoverageFilePaths: [
+                "/path1",
+                "/path2",
+            ],
+        };
+        const service = new CoverageService(config, mockOutputChannel);
+
+        let globPassed;
+        (workspace as any).createFileSystemWatcher = (glob) => {
+            globPassed = glob;
+            return {
+                onDidChange: (fn) => {},
+                onDidCreate: (fn) => {},
+                onDidDelete: (fn) => {},
+            };
+        };
+        (service as any).listenToFileSystem();
+
+        assert.equal(globPassed, "{/path1,/path2}");
+    });
+});


### PR DESCRIPTION
# Rational
I would like to use manualCoverageFilePaths with a set of explicit lcov files and avoid glob lookups, in order to optimize coverage-gutter on big workspaces.

`createFileSystemWatcher` works well with the glob pattern which contains files inside and outside of the workspace and successfully watches files that are inside workspace folders

# Changes
Update `listenToFileSystem` to listen for `manualCoverageFilePaths` if they are provided

## Tested on
```
Version: 1.47.1
Commit: 485c41f9460bdb830c4da12c102daff275415b53
Date: 2020-07-13T22:43:02.577Z
Electron: 7.3.2
Chrome: 78.0.3904.130
Node.js: 12.8.1
V8: 7.8.279.23-electron.0
OS: Darwin x64 19.6.0
```