### PR TITLE
Make base glob configurable via coverageBaseDir

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,11 @@
           "default": [],
           "description": "take manual control over the absolute path to your coverage file(s)"
         },
+        "coverage-gutters.coverageBaseDir": {
+          "type": "string",
+          "default": "**",
+          "description": "workspaceFolder relative path or glob that will be used for coverage file lookup `${coverageBaseDir}/{${coverageFileNames}}`"
+        },
         "coverage-gutters.coverageFileNames": {
           "type": "array",
           "default": [

--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -135,6 +135,8 @@ export class CoverageService {
         const fileNames = this.configStore.coverageFileNames.toString();
         let baseDir = this.configStore.coverageBaseDir;
         if (workspace.workspaceFolders) {
+            // Prepend workspace folders glob to the folder lookup glob
+            // This allows watching within all the workspace folders
             const workspaceFolders = workspace.workspaceFolders.map((wf) => wf.uri.fsPath);
             baseDir = `{${workspaceFolders}}/${baseDir}`;
         }

--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -140,7 +140,7 @@ export class CoverageService {
         }
 
         // Creates a BlobPattern for all coverage files.
-        // EX: `**/{cov.xml, lcov.info}`
+        // EX: `{/path/to/workspace1, /path/to/workspace2}/**/{cov.xml, lcov.info}`
         const blobPattern = `${baseDir}/{${fileNames}}`;
         this.coverageWatcher = workspace.createFileSystemWatcher(blobPattern);
         this.coverageWatcher.onDidChange(this.loadCacheAndRender.bind(this));

--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -133,9 +133,15 @@ export class CoverageService {
         if (this.configStore.manualCoverageFilePaths.length) { return; }
 
         const fileNames = this.configStore.coverageFileNames.toString();
+        let baseDir = this.configStore.coverageBaseDir;
+        if (workspace.workspaceFolders) {
+            const workspaceFolders = workspace.workspaceFolders.map((wf) => wf.uri.fsPath);
+            baseDir = `{${workspaceFolders}}/${baseDir}`;
+        }
+
         // Creates a BlobPattern for all coverage files.
         // EX: `**/{cov.xml, lcov.info}`
-        const blobPattern = `**/{${fileNames}}`;
+        const blobPattern = `${baseDir}/{${fileNames}}`;
         this.coverageWatcher = workspace.createFileSystemWatcher(blobPattern);
         this.coverageWatcher.onDidChange(this.loadCacheAndRender.bind(this));
         this.coverageWatcher.onDidCreate(this.loadCacheAndRender.bind(this));

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -9,6 +9,7 @@ import {
 } from "vscode";
 
 export class Config {
+    public coverageBaseDir: string;
     public coverageFileNames: string[];
     public reportFileName: string;
     public fullCoverageDecorationType: TextEditorDecorationType;
@@ -48,6 +49,7 @@ export class Config {
         const lcovName = rootConfig.get("lcovname") as string;
         const xmlName = rootConfig.get("xmlname") as string;
         this.reportFileName = rootConfig.get("coverageReportFileName") as string;
+        this.coverageBaseDir = rootConfig.get("coverageBaseDir") as string;
         this.coverageFileNames = rootConfig.get("coverageFileNames") as string[];
         this.coverageFileNames.push(lcovName, xmlName);
         this.coverageFileNames = this.coverageFileNames.filter((name) => !!name.trim());

--- a/src/files/filesloader.ts
+++ b/src/files/filesloader.ts
@@ -84,7 +84,7 @@ export class FilesLoader {
         fileName: string,
     ) {
         return new Promise<Set<string>>((resolve, reject) => {
-            glob(`**/${fileName}`,
+            glob(`${this.configStore.coverageBaseDir}/${fileName}`,
                 {
                     cwd: workspaceFolder.uri.fsPath,
                     dot: true,

--- a/test/coverage-system/coverageservice.test.ts
+++ b/test/coverage-system/coverageservice.test.ts
@@ -40,6 +40,7 @@ suite("CoverageService Tests", function() {
 
     test("Should listen for coverage file names in workspace @unit", function() {
         const config: any = {
+            coverageBaseDir: "custom/path/*",
             coverageFileNames: [
                 "coverage.xml",
                 "custom-lcov.info",
@@ -55,6 +56,11 @@ suite("CoverageService Tests", function() {
         };
         (service as any).listenToFileSystem();
 
-        assert.equal(globPassed, "**/{coverage.xml,custom-lcov.info}");
+        let prefix = config.coverageBaseDir;
+        if (workspace.workspaceFolders) {
+            const workspaceFolders = workspace.workspaceFolders.map((wf) => wf.uri.fsPath);
+            prefix = `{${workspaceFolders}}/${prefix}`;
+        }
+        assert.equal(globPassed, `${prefix}/{coverage.xml,custom-lcov.info}`);
     });
 });


### PR DESCRIPTION
# Rational

On big workspaces (e.g. 12k directories, 74k files) recursive glob lookup `**` is very time consuming. Currently there is no way to avoid it via configuration options. 
`manualCoverageFilePaths` is the only option, however it eliminates any kind of glob lookup, which is not desired.

# Change

Introduce `coverageBaseDir` that allows users to fully customize lookup glob for coverage files
It defaults to `**`, so existing behavior is not going to change.