### PR TITLE
Allow named workspace folders

### DIFF
--- a/src/coverage-system/sectionfinder.ts
+++ b/src/coverage-system/sectionfinder.ts
@@ -1,5 +1,5 @@
 import {Section} from "lcov-parse";
-import {extname} from "path";
+import {basename} from "path";
 import {TextEditor, Uri, workspace} from "vscode";
 import {OutputChannel} from "vscode";
 import {Config} from "../extension/config";
@@ -116,7 +116,7 @@ export class SectionFinder {
         const editorFileAbs = normalizeFileName(fileName);
         const workspaceFile = normalizeFileName(workspaceFsPath);
         const editorFileRelative = editorFileAbs.substring(workspaceFile.length);
-        const workspaceFolderName = normalizeFileName(workspaceFolder.name);
+        const workspaceFolderName = normalizeFileName(basename(workspaceFsPath));
         return { relativePath: editorFileRelative, workspaceFolder: workspaceFolderName};
     }
 

--- a/test/coverage-system/sectionfinder.test.ts
+++ b/test/coverage-system/sectionfinder.test.ts
@@ -1,10 +1,17 @@
-import {Section} from "lcov-parse";
-import {TextEditor} from "vscode";
+import * as assert from "assert";
+import { Section } from "lcov-parse";
+import { basename, join } from "path";
+import { TextEditor, Uri, workspace, WorkspaceFolder } from "vscode";
 
-import {SectionFinder} from "../../src/coverage-system/sectionfinder";
-import {fakeConfig} from "../mocks/fakeConfig";
+import { SectionFinder } from "../../src/coverage-system/sectionfinder";
+import { fakeConfig } from "../mocks/fakeConfig";
+
+const getWorkspaceFolder = workspace.getWorkspaceFolder;
 
 suite("SectionFinder Tests", function() {
+    teardown(function() {
+        (workspace as any).getWorkspaceFolder = getWorkspaceFolder;
+    });
 
     const fakeOutput = {
         append: () => {},
@@ -15,14 +22,74 @@ suite("SectionFinder Tests", function() {
         name: "fake",
         show: () => {},
     };
+    const filename = "test123.ts";
+    const title = `00-${filename}`;
+    const testFolderPath = "/path/to/test/folder";
+    const filePath = join(testFolderPath, "test123.ts");
+    const testWorkspaceFolder: WorkspaceFolder = {
+        index: 0,
+        name: basename(testFolderPath),
+        uri: Uri.file(testFolderPath),
+    };
+    const textEditor: TextEditor = {} as TextEditor;
+    (textEditor as any).document = {};
+    (textEditor as any).document.fileName = filePath;
+    const sectionMap: Map<string, Section> = new Map<string, Section>([
+        [
+            `${title}::${filePath}`,
+            {
+                file: filePath,
+                functions: {
+                    details: [],
+                    found: 0,
+                    hit: 0,
+                },
+                lines: {
+                    details: [],
+                    found: 0,
+                    hit: 0,
+                },
+                title,
+            },
+        ],
+    ]);
+    const sectionFinder: SectionFinder = new SectionFinder(
+        fakeConfig,
+        fakeOutput,
+    );
+    const createWorkspaceFolderMock = (workspaceFolder: WorkspaceFolder): (uri: Uri) => WorkspaceFolder => {
+        return (uri: Uri): WorkspaceFolder => {
+            if (uri.path === textEditor.document.fileName) {
+                return workspaceFolder;
+            }
 
-    test("Should not throw an error @unit", function(done) {
-        const textEditor: TextEditor = {} as TextEditor;
-        (textEditor as any).document = {};
-        (textEditor as any).document.fileName = "test123.ts";
-        const sectionMap: Map<string, Section> = new Map<string, Section>();
-        const sectionFinder: SectionFinder = new SectionFinder(fakeConfig, fakeOutput);
-        sectionFinder.findSectionsForEditor(textEditor, sectionMap);
+            throw new Error("Invalid filename given");
+        };
+    };
+
+    test("Should handle workspace folders without names", function(done) {
+        (workspace as any).getWorkspaceFolder = createWorkspaceFolderMock(testWorkspaceFolder);
+        const sections = sectionFinder.findSectionsForEditor(
+            textEditor,
+            sectionMap,
+        );
+
+        assert.equal(sections.length, 1);
+        return done();
+    });
+
+    test("Should handle workspace folders with names", function(done) {
+        const workspaceFolderWithName: WorkspaceFolder = {
+            ...testWorkspaceFolder,
+            name: "Test Folder",
+        };
+        (workspace as any).getWorkspaceFolder = createWorkspaceFolderMock(workspaceFolderWithName);
+        const sections = sectionFinder.findSectionsForEditor(
+            textEditor,
+            sectionMap,
+        );
+
+        assert.equal(sections.length, 1);
         return done();
     });
 });


### PR DESCRIPTION
This PR fixes #252.

The change is to use the base name of the path for the workspace folder instead of the name, which defaults to the path's base name if a name hasn't been specified. I've tested that this works in my setup (VS Code 1.54.2 running on Linux), and have added unit tests to cover the cases where a name has or hasn't been specified.