### PR TITLE
Enable custom svgs to be provided via config options

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,32 +76,26 @@
         },
         "coverage-gutters.gutterIconPathLight": {
           "type": "string",
-          "default": "./app_images/gutter-icon-light.svg",
           "description": "path to an icon (svg, png, etc) for displaying in the gutter for full coverage"
         },
         "coverage-gutters.gutterIconPathDark": {
           "type": "string",
-          "default": "./app_images/gutter-icon-dark.svg",
           "description": "path to an icon (svg, png, etc) for displaying in the gutter for full coverage"
         },
         "coverage-gutters.partialGutterIconPathLight": {
           "type": "string",
-          "default": "./app_images/partial-gutter-icon-light.svg",
           "description": "path to an icon (svg, png, etc) for displaying in the gutter for partial coverage"
         },
         "coverage-gutters.partialGutterIconPathDark": {
           "type": "string",
-          "default": "./app_images/partial-gutter-icon-dark.svg",
           "description": "path to an icon (svg, png, etc) for displaying in the gutter for partial coverage"
         },
         "coverage-gutters.noGutterIconPathLight": {
           "type": "string",
-          "default": "./app_images/no-gutter-icon-light.svg",
           "description": "path to an icon (svg, png, etc) for displaying in the gutter for no coverage"
         },
         "coverage-gutters.noGutterIconPathDark": {
           "type": "string",
-          "default": "./app_images/no-gutter-icon-dark.svg",
           "description": "path to an icon (svg, png, etc) for displaying in the gutter for no coverage"
         },
         "coverage-gutters.showLineCoverage": {

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -70,27 +70,34 @@ export class Config {
         const partialCoverageDarkBackgroundColour = rootConfig.get("partialHighlightDark") as string;
         const noCoverageLightBackgroundColour = rootConfig.get("noHighlightLight") as string;
         const noCoverageDarkBackgroundColour = rootConfig.get("noHighlightDark") as string;
-        const gutterIconPathDark = rootConfig.get("gutterIconPathDark") as string;
-        const gutterIconPathLight = rootConfig.get("gutterIconPathLight") as string;
-        const partialGutterIconPathDark = rootConfig.get("partialGutterIconPathDark") as string;
-        const partialGutterIconPathLight = rootConfig.get("partialGutterIconPathLight") as string;
-        const noGutterIconPathDark = rootConfig.get("noGutterIconPathDark") as string;
-        const noGutterIconPathLight = rootConfig.get("noGutterIconPathLight") as string;
         const showGutterCoverage = rootConfig.get("showGutterCoverage") as string;
         const showLineCoverage = rootConfig.get("showLineCoverage") as string;
         const showRulerCoverage = rootConfig.get("showRulerCoverage") as string;
+
+        const defaultIcons = {
+            gutterIconPathDark: "./app_images/gutter-icon-dark.svg",
+            gutterIconPathLight: "./app_images/gutter-icon-light.svg",
+            noGutterIconPathDark: "./app_images/no-gutter-icon-dark.svg",
+            noGutterIconPathLight: "./app_images/no-gutter-icon-light.svg",
+            partialGutterIconPathDark: "./app_images/partial-gutter-icon-dark.svg",
+            partialGutterIconPathLight: "./app_images/partial-gutter-icon-light.svg",
+        };
+
+        const getIcon = (name: string): string =>
+            rootConfig.get(name) as string ||
+            this.context.asAbsolutePath(defaultIcons[name]);
 
         // Setup info for decorations
         const fullDecoration: DecorationRenderOptions = {
             dark: {
                 backgroundColor: showLineCoverage ? coverageDarkBackgroundColour : "",
-                gutterIconPath: showGutterCoverage ? this.context.asAbsolutePath(gutterIconPathDark) : "",
+                gutterIconPath: showGutterCoverage ? getIcon("gutterIconPathDark") : "",
                 overviewRulerColor: showRulerCoverage ? coverageDarkBackgroundColour : "",
             },
             isWholeLine: true,
             light: {
                 backgroundColor: showLineCoverage ? coverageLightBackgroundColour : "",
-                gutterIconPath: showGutterCoverage ? this.context.asAbsolutePath(gutterIconPathLight) : "",
+                gutterIconPath: showGutterCoverage ? getIcon("gutterIconPathLight") : "",
                 overviewRulerColor: showRulerCoverage ? coverageLightBackgroundColour : "",
             },
             overviewRulerLane: OverviewRulerLane.Full,
@@ -99,13 +106,13 @@ export class Config {
         const partialDecoration: DecorationRenderOptions = {
             dark: {
                 backgroundColor: showLineCoverage ? partialCoverageDarkBackgroundColour : "",
-                gutterIconPath: showGutterCoverage ? this.context.asAbsolutePath(partialGutterIconPathDark) : "",
+                gutterIconPath: showGutterCoverage ? getIcon("partialGutterIconPathDark") : "",
                 overviewRulerColor: showRulerCoverage ? partialCoverageDarkBackgroundColour : "",
             },
             isWholeLine: true,
             light: {
                 backgroundColor: showLineCoverage ? partialCoverageLightBackgroundColour : "",
-                gutterIconPath: showGutterCoverage ? this.context.asAbsolutePath(partialGutterIconPathLight) : "",
+                gutterIconPath: showGutterCoverage ? getIcon("partialGutterIconPathLight") : "",
                 overviewRulerColor: showRulerCoverage ? partialCoverageLightBackgroundColour : "",
             },
             overviewRulerLane: OverviewRulerLane.Full,
@@ -114,13 +121,13 @@ export class Config {
         const noDecoration: DecorationRenderOptions = {
             dark: {
                 backgroundColor: showLineCoverage ? noCoverageDarkBackgroundColour : "",
-                gutterIconPath: showGutterCoverage ? this.context.asAbsolutePath(noGutterIconPathDark) : "",
+                gutterIconPath: showGutterCoverage ? getIcon("noGutterIconPathDark") : "",
                 overviewRulerColor: showRulerCoverage ? noCoverageDarkBackgroundColour : "",
             },
             isWholeLine: true,
             light: {
                 backgroundColor: showLineCoverage ? noCoverageLightBackgroundColour : "",
-                gutterIconPath: showGutterCoverage ? this.context.asAbsolutePath(noGutterIconPathLight) : "",
+                gutterIconPath: showGutterCoverage ? getIcon("noGutterIconPathLight") : "",
                 overviewRulerColor: showRulerCoverage ? noCoverageLightBackgroundColour : "",
             },
             overviewRulerLane: OverviewRulerLane.Full,

--- a/test/extension/config.test.ts
+++ b/test/extension/config.test.ts
@@ -8,6 +8,10 @@ const createTextEditorDecorationType = vscode.window.createTextEditorDecorationT
 const executeCommand = vscode.commands.executeCommand;
 const getConfiguration = vscode.workspace.getConfiguration;
 
+let showGutterCoverage: boolean;
+let iconPathDark: string;
+let iconPathLight: string;
+
 suite("Config Tests", function() {
     const fakeVscode: any = {
         createTextEditorDecorationType: (options) => {
@@ -27,6 +31,12 @@ suite("Config Tests", function() {
                         return ["test.xml", "lcov.info"];
                     } else if (key === "lcovname") {
                         return "lcov.info";
+                    } else if (key === "showGutterCoverage") {
+                        return showGutterCoverage;
+                    } else if (key.includes("IconPathDark")) {
+                        return iconPathDark;
+                    } else if (key.includes("IconPathLight")) {
+                        return iconPathLight;
                     }
                     return "123";
                 },
@@ -74,12 +84,25 @@ suite("Config Tests", function() {
         assert.equal(config.coverageFileNames.length, 3);
     });
 
-    test("Should remove gutter icons if path is blank, allows breakpoint usage @unit", function() {
+    test("Should remove gutter icons if showGutterCoverage is set to false, allows breakpoint usage @unit", function() {
+        showGutterCoverage = false;
         (vscode as any).window.createTextEditorDecorationType = (options) => {
             assert.equal("gutterIconPath" in options.dark, false);
             assert.equal("gutterIconPath" in options.light, false);
         };
-        fakeContext.asAbsolutePath = (options) => "";
         new Config(fakeContext); // tslint:disable-line
     });
+
+    test("Should set the gutter icon to the provided value if set @unit", function() {
+        showGutterCoverage = true;
+        iconPathDark = "/my/absolute/path/to/custom/icon-dark.svg";
+        iconPathLight = "";
+        (vscode as any).window.createTextEditorDecorationType = (options) => {
+            assert.equal(options.dark.gutterIconPath, iconPathDark);
+            assert.equal(options.light.gutterIconPath.includes("./app_images/"), true);
+        };
+        fakeContext.asAbsolutePath = (options) => options;
+        new Config(fakeContext); // tslint:disable-line
+    });
+
 });


### PR DESCRIPTION
I ran into an issue today whilst trying to update the colors of gutters' SVGs (same issue as detailed in #239).

These changes are designed to enable users to have permanently saved SVGs somewhere on disk.