### PR TITLE
Issue 289: Add line coverage to status bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,41 @@
         "tslib": "^1.9.3"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -244,6 +279,15 @@
         "@types/form-data": "*",
         "@types/node": "*",
         "@types/tough-cookie": "*"
+      }
+    },
+    "@types/sinon": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.2.tgz",
+      "integrity": "sha512-BHn8Bpkapj8Wdfxvh2jWIUoaYB/9/XhsL0oOvBfRagJtKlSl9NWPcFOz2lRukI9szwGxFtYZCTejJSqsGDbdmw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/fake-timers": "^7.1.0"
       }
     },
     "@types/tough-cookie": {
@@ -1283,6 +1327,12 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -1605,6 +1655,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -1908,6 +1964,19 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -2090,6 +2159,23 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -2258,6 +2344,43 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
+      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "slice-ansi": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -270,6 +270,7 @@
     "@types/mocha": "5.2.6",
     "@types/node": "10.14.6",
     "@types/request": "2.48.1",
+    "@types/sinon": "^10.0.2",
     "@types/uuid": "8.0.0",
     "@types/vscode": "1.27.0",
     "chai": "4.2.0",
@@ -277,6 +278,7 @@
     "husky": "6.0.0",
     "lint-staged": "11.0.0",
     "mocha": "6.1.4",
+    "sinon": "^11.1.1",
     "tslint": "5.16.0",
     "typescript": "4.2.3",
     "vscode-test": "1.5.2"

--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -183,7 +183,7 @@ export class CoverageService {
     }
 
     private listenToEditorEvents() {
-        window.onDidChangeActiveTextEditor(
+        this.editorWatcher = window.onDidChangeActiveTextEditor(
             this.handleEditorEvents.bind(this),
         );
     }

--- a/src/extension/statusbartoggler.ts
+++ b/src/extension/statusbartoggler.ts
@@ -6,9 +6,11 @@ export class StatusBarToggler implements Disposable {
     private static readonly removeCommand = "coverage-gutters.removeWatch";
     private static readonly watchText = "Watch";
     private static readonly coverageText = "Coverage";
-    private static readonly listIcon = "$(list-ordered)";
+    private static readonly listIcon = "$(list-ordered) ";
     private static readonly loadingIcon = "$(loading~spin) ";
-    private static readonly toolTip = "Coverage Gutters: Watch and Remove Helper";
+    private static readonly watchToolTip = "Coverage Gutters: Click to watch workspace.";
+    private static readonly removeWatchToolTip = "Coverage Gutters: Click to remove watch from workspace.";
+
     public isActive: boolean;
     public isLoading: boolean;
     public lineCoverage: string | undefined;
@@ -19,7 +21,7 @@ export class StatusBarToggler implements Disposable {
         this.statusBarItem = window.createStatusBarItem();
         this.statusBarItem.command = StatusBarToggler.watchCommand;
         this.statusBarItem.text = StatusBarToggler.watchText;
-        this.statusBarItem.tooltip = StatusBarToggler.toolTip;
+        this.statusBarItem.tooltip = StatusBarToggler.watchToolTip;
         this.configStore = configStore;
         this.isLoading = false;
         this.lineCoverage = undefined;
@@ -61,18 +63,25 @@ export class StatusBarToggler implements Disposable {
         this.statusBarItem.dispose();
     }
 
+    private getCoverageText() {
+        if (this.lineCoverage) {
+            return [StatusBarToggler.coverageText, this.lineCoverage].join(" ");
+        }
+        return ["No", StatusBarToggler.coverageText].join(" ");
+    }
+
     /**
      * update
-     * @description Updates the text displayed in the StatusBarToggler
+     * @description Updates the text and tooltip displayed by the StatusBarToggler
      */
     private update() {
         if (this.isActive) {
             this.statusBarItem.command = StatusBarToggler.removeCommand;
-            this.statusBarItem.text = this.lineCoverage ?
-            [StatusBarToggler.coverageText, this.lineCoverage].join(" ") :
-            ["No", StatusBarToggler.coverageText].join(" ");
+            this.statusBarItem.tooltip = StatusBarToggler.removeWatchToolTip;
+            this.statusBarItem.text = this.getCoverageText();
         } else {
             this.statusBarItem.command = StatusBarToggler.watchCommand;
+            this.statusBarItem.tooltip = StatusBarToggler.watchToolTip;
             this.statusBarItem.text = StatusBarToggler.watchText;
         }
         if (this.isLoading) {

--- a/src/extension/statusbartoggler.ts
+++ b/src/extension/statusbartoggler.ts
@@ -2,13 +2,17 @@ import { Disposable, StatusBarItem, window } from "vscode";
 import { Config } from "./config";
 
 export class StatusBarToggler implements Disposable {
-    private static readonly watchCommand = "coverage-gutters.watchCoverageAndVisibleEditors";
-    private static readonly removeCommand = "coverage-gutters.removeWatch";
-    private static readonly watchText = "Watch";
     private static readonly coverageText = "Coverage";
-    private static readonly listIcon = "$(list-ordered)";
-    private static readonly loadingIcon = "$(loading~spin)";
+
+    private static readonly loadingText = ["$(loading~spin)", StatusBarToggler.coverageText].join(" ");
+
+    private static readonly idleIcon = "$(circle-large-outline)";
+
+    private static readonly watchCommand = "coverage-gutters.watchCoverageAndVisibleEditors";
+    private static readonly watchText = [StatusBarToggler.idleIcon, "Watch"].join(" ");
     private static readonly watchToolTip = "Coverage Gutters: Click to watch workspace.";
+
+    private static readonly removeCommand = "coverage-gutters.removeWatch";
     private static readonly removeWatchToolTip = "Coverage Gutters: Click to remove watch from workspace.";
 
     public isActive: boolean;
@@ -65,10 +69,10 @@ export class StatusBarToggler implements Disposable {
 
     private getStatusBarText() {
         if (this.isLoading) {
-            return [StatusBarToggler.loadingIcon, StatusBarToggler.coverageText].join(" ");
+            return StatusBarToggler.loadingText;
         }
         if (this.isActive) {
-            return [StatusBarToggler.listIcon, this.lineCoverage || "No", StatusBarToggler.coverageText].join(" ");
+            return [StatusBarToggler.idleIcon, this.lineCoverage || "No", StatusBarToggler.coverageText].join(" ");
         }
         return StatusBarToggler.watchText;
     }

--- a/src/extension/statusbartoggler.ts
+++ b/src/extension/statusbartoggler.ts
@@ -64,10 +64,7 @@ export class StatusBarToggler implements Disposable {
     }
 
     private getCoverageText() {
-        if (this.lineCoverage) {
-            return [StatusBarToggler.coverageText, this.lineCoverage].join(" ");
-        }
-        return ["No", StatusBarToggler.coverageText].join(" ");
+        return [this.lineCoverage || "No", StatusBarToggler.coverageText].join(" ");
     }
 
     /**

--- a/src/extension/statusbartoggler.ts
+++ b/src/extension/statusbartoggler.ts
@@ -5,12 +5,14 @@ export class StatusBarToggler implements Disposable {
     private static readonly watchCommand = "coverage-gutters.watchCoverageAndVisibleEditors";
     private static readonly removeCommand = "coverage-gutters.removeWatch";
     private static readonly watchText = "Watch";
-    private static readonly removeText = "Remove Watch";
+    private static readonly watchingText = "Watching";
+    private static readonly coverageText = "Coverage ";
     private static readonly listIcon = "$(list-ordered) ";
     private static readonly loadingIcon = "$(loading~spin) ";
     private static readonly toolTip = "Coverage Gutters: Watch and Remove Helper";
     public isActive: boolean;
     public isLoading: boolean;
+    public lineCoverage: string | undefined;
     private statusBarItem: StatusBarItem;
     private configStore: Config;
 
@@ -21,6 +23,7 @@ export class StatusBarToggler implements Disposable {
         this.statusBarItem.tooltip = StatusBarToggler.toolTip;
         this.configStore = configStore;
         this.isLoading = false;
+        this.lineCoverage = undefined;
 
         if (this.configStore.showStatusBarToggler) { this.statusBarItem.show(); }
     }
@@ -43,6 +46,15 @@ export class StatusBarToggler implements Disposable {
         this.update();
     }
 
+    public setCoverage(linePercentage: number | undefined ) {
+        if (Number.isFinite(linePercentage)) {
+            this.lineCoverage = `${linePercentage}%`;
+        } else {
+            this.lineCoverage = undefined;
+        }
+        this.update();
+    }
+
     /**
      * Cleans up the statusBarItem if asked to dispose
      */
@@ -57,7 +69,9 @@ export class StatusBarToggler implements Disposable {
     private update() {
         if (this.isActive) {
             this.statusBarItem.command = StatusBarToggler.removeCommand;
-            this.statusBarItem.text = StatusBarToggler.removeText;
+            this.statusBarItem.text = this.lineCoverage ?
+            StatusBarToggler.coverageText + this.lineCoverage :
+            StatusBarToggler.watchingText;
         } else {
             this.statusBarItem.command = StatusBarToggler.watchCommand;
             this.statusBarItem.text = StatusBarToggler.watchText;

--- a/src/extension/statusbartoggler.ts
+++ b/src/extension/statusbartoggler.ts
@@ -63,10 +63,6 @@ export class StatusBarToggler implements Disposable {
         this.statusBarItem.dispose();
     }
 
-    private getCoverageText() {
-        return [this.lineCoverage || "No", StatusBarToggler.coverageText].join(" ");
-    }
-
     /**
      * update
      * @description Updates the text and tooltip displayed by the StatusBarToggler
@@ -75,7 +71,7 @@ export class StatusBarToggler implements Disposable {
         if (this.isActive) {
             this.statusBarItem.command = StatusBarToggler.removeCommand;
             this.statusBarItem.tooltip = StatusBarToggler.removeWatchToolTip;
-            this.statusBarItem.text = this.getCoverageText();
+            this.statusBarItem.text = [this.lineCoverage || "No", StatusBarToggler.coverageText].join(" ");
         } else {
             this.statusBarItem.command = StatusBarToggler.watchCommand;
             this.statusBarItem.tooltip = StatusBarToggler.watchToolTip;

--- a/src/extension/statusbartoggler.ts
+++ b/src/extension/statusbartoggler.ts
@@ -5,9 +5,8 @@ export class StatusBarToggler implements Disposable {
     private static readonly watchCommand = "coverage-gutters.watchCoverageAndVisibleEditors";
     private static readonly removeCommand = "coverage-gutters.removeWatch";
     private static readonly watchText = "Watch";
-    private static readonly watchingText = "Watching";
-    private static readonly coverageText = "Coverage ";
-    private static readonly listIcon = "$(list-ordered) ";
+    private static readonly coverageText = "Coverage";
+    private static readonly listIcon = "$(list-ordered)";
     private static readonly loadingIcon = "$(loading~spin) ";
     private static readonly toolTip = "Coverage Gutters: Watch and Remove Helper";
     public isActive: boolean;
@@ -70,8 +69,8 @@ export class StatusBarToggler implements Disposable {
         if (this.isActive) {
             this.statusBarItem.command = StatusBarToggler.removeCommand;
             this.statusBarItem.text = this.lineCoverage ?
-            StatusBarToggler.coverageText + this.lineCoverage :
-            StatusBarToggler.watchingText;
+            [StatusBarToggler.coverageText, this.lineCoverage].join(" ") :
+            ["No", StatusBarToggler.coverageText].join(" ");
         } else {
             this.statusBarItem.command = StatusBarToggler.watchCommand;
             this.statusBarItem.text = StatusBarToggler.watchText;

--- a/src/extension/statusbartoggler.ts
+++ b/src/extension/statusbartoggler.ts
@@ -6,8 +6,8 @@ export class StatusBarToggler implements Disposable {
     private static readonly removeCommand = "coverage-gutters.removeWatch";
     private static readonly watchText = "Watch";
     private static readonly coverageText = "Coverage";
-    private static readonly listIcon = "$(list-ordered) ";
-    private static readonly loadingIcon = "$(loading~spin) ";
+    private static readonly listIcon = "$(list-ordered)";
+    private static readonly loadingIcon = "$(loading~spin)";
     private static readonly watchToolTip = "Coverage Gutters: Click to watch workspace.";
     private static readonly removeWatchToolTip = "Coverage Gutters: Click to remove watch from workspace.";
 
@@ -63,24 +63,29 @@ export class StatusBarToggler implements Disposable {
         this.statusBarItem.dispose();
     }
 
+    private getStatusBarText() {
+        if (this.isLoading) {
+            return [StatusBarToggler.loadingIcon, StatusBarToggler.coverageText].join(" ");
+        }
+        if (this.isActive) {
+            return [StatusBarToggler.listIcon, this.lineCoverage || "No", StatusBarToggler.coverageText].join(" ");
+        }
+        return StatusBarToggler.watchText;
+    }
+
     /**
      * update
      * @description Updates the text and tooltip displayed by the StatusBarToggler
      */
     private update() {
+        this.statusBarItem.text = this.getStatusBarText();
+
         if (this.isActive) {
             this.statusBarItem.command = StatusBarToggler.removeCommand;
             this.statusBarItem.tooltip = StatusBarToggler.removeWatchToolTip;
-            this.statusBarItem.text = [this.lineCoverage || "No", StatusBarToggler.coverageText].join(" ");
         } else {
             this.statusBarItem.command = StatusBarToggler.watchCommand;
             this.statusBarItem.tooltip = StatusBarToggler.watchToolTip;
-            this.statusBarItem.text = StatusBarToggler.watchText;
-        }
-        if (this.isLoading) {
-            this.statusBarItem.text = StatusBarToggler.loadingIcon + this.statusBarItem.text;
-        } else {
-            this.statusBarItem.text = StatusBarToggler.listIcon + this.statusBarItem.text;
         }
     }
 }

--- a/test/extension/statusbartoggler.test.ts
+++ b/test/extension/statusbartoggler.test.ts
@@ -41,13 +41,13 @@ suite("Status Bar Toggler Tests", () => {
         statusBarToggler.setLoading(false);
         assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
         statusBarToggler.setCoverage(84);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Coverage 84%");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) 84% Coverage");
         statusBarToggler.setCoverage(undefined);
         assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
         statusBarToggler.setCoverage(50);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Coverage 50%");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) 50% Coverage");
         statusBarToggler.setCoverage(0);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Coverage 0%");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) 0% Coverage");
     });
 
     test("Should dispose when asked @unit", () => {

--- a/test/extension/statusbartoggler.test.ts
+++ b/test/extension/statusbartoggler.test.ts
@@ -6,23 +6,23 @@ suite("Status Bar Toggler Tests", () => {
     test("Should toggle showStatusBarToggler command and message @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) No Coverage");
     });
 
     test("Should not toggle twice showStatusBarToggler command and message @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) No Coverage");
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) No Coverage");
     });
 
     test("Should toggle showStatusBarToggler command and message back to \"Watch\" @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) No Coverage");
         statusBarToggler.toggle(false);
-        assert.equal(statusBarToggler.statusText, "Watch");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) Watch");
     });
 
     test("Should show the spinner when setting the `isLoading` status @unit", () => {
@@ -32,22 +32,22 @@ suite("Status Bar Toggler Tests", () => {
         statusBarToggler.toggle(true);
         assert.equal(statusBarToggler.statusText, "$(loading~spin) Coverage");
         statusBarToggler.setLoading(false);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) No Coverage");
     });
 
     test("Should show coverage when a number is set @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
         statusBarToggler.setLoading(false);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) No Coverage");
         statusBarToggler.setCoverage(84);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) 84% Coverage");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) 84% Coverage");
         statusBarToggler.setCoverage(undefined);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) No Coverage");
         statusBarToggler.setCoverage(50);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) 50% Coverage");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) 50% Coverage");
         statusBarToggler.setCoverage(0);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) 0% Coverage");
+        assert.equal(statusBarToggler.statusText, "$(circle-large-outline) 0% Coverage");
     });
 
     test("Should dispose when asked @unit", () => {

--- a/test/extension/statusbartoggler.test.ts
+++ b/test/extension/statusbartoggler.test.ts
@@ -6,21 +6,21 @@ suite("Status Bar Toggler Tests", () => {
     test("Should toggle showStatusBarToggler command and message @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
     });
 
     test("Should not toggle twice showStatusBarToggler command and message @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
     });
 
     test("Should toggle showStatusBarToggler command and message back to \"Watch\" @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
         statusBarToggler.toggle(false);
         assert.equal(statusBarToggler.statusText, "$(list-ordered) Watch");
     });
@@ -30,20 +30,20 @@ suite("Status Bar Toggler Tests", () => {
         statusBarToggler.setLoading(true);
         assert.equal(statusBarToggler.statusText, "$(loading~spin) Watch");
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(loading~spin) Watching");
+        assert.equal(statusBarToggler.statusText, "$(loading~spin) No Coverage");
         statusBarToggler.setLoading(false);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
     });
 
     test("Should show coverage when a number is set @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
         statusBarToggler.setLoading(false);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
         statusBarToggler.setCoverage(84);
         assert.equal(statusBarToggler.statusText, "$(list-ordered) Coverage 84%");
         statusBarToggler.setCoverage(undefined);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
         statusBarToggler.setCoverage(50);
         assert.equal(statusBarToggler.statusText, "$(list-ordered) Coverage 50%");
         statusBarToggler.setCoverage(0);

--- a/test/extension/statusbartoggler.test.ts
+++ b/test/extension/statusbartoggler.test.ts
@@ -6,21 +6,21 @@ suite("Status Bar Toggler Tests", () => {
     test("Should toggle showStatusBarToggler command and message @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Remove Watch");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
     });
 
     test("Should not toggle twice showStatusBarToggler command and message @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Remove Watch");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Remove Watch");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
     });
 
     test("Should toggle showStatusBarToggler command and message back to \"Watch\" @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Remove Watch");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
         statusBarToggler.toggle(false);
         assert.equal(statusBarToggler.statusText, "$(list-ordered) Watch");
     });
@@ -30,9 +30,24 @@ suite("Status Bar Toggler Tests", () => {
         statusBarToggler.setLoading(true);
         assert.equal(statusBarToggler.statusText, "$(loading~spin) Watch");
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(loading~spin) Remove Watch");
+        assert.equal(statusBarToggler.statusText, "$(loading~spin) Watching");
         statusBarToggler.setLoading(false);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Remove Watch");
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
+    });
+
+    test("Should show coverage when a number is set @unit", () => {
+        const statusBarToggler = new StatusBarToggler(fakeConfig);
+        statusBarToggler.toggle(true);
+        statusBarToggler.setLoading(false);
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
+        statusBarToggler.setCoverage(84);
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) Coverage 84%");
+        statusBarToggler.setCoverage(undefined);
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watching");
+        statusBarToggler.setCoverage(50);
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) Coverage 50%");
+        statusBarToggler.setCoverage(0);
+        assert.equal(statusBarToggler.statusText, "$(list-ordered) Coverage 0%");
     });
 
     test("Should dispose when asked @unit", () => {

--- a/test/extension/statusbartoggler.test.ts
+++ b/test/extension/statusbartoggler.test.ts
@@ -22,15 +22,15 @@ suite("Status Bar Toggler Tests", () => {
         statusBarToggler.toggle(true);
         assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
         statusBarToggler.toggle(false);
-        assert.equal(statusBarToggler.statusText, "$(list-ordered) Watch");
+        assert.equal(statusBarToggler.statusText, "Watch");
     });
 
     test("Should show the spinner when setting the `isLoading` status @unit", () => {
         const statusBarToggler = new StatusBarToggler(fakeConfig);
         statusBarToggler.setLoading(true);
-        assert.equal(statusBarToggler.statusText, "$(loading~spin) Watch");
+        assert.equal(statusBarToggler.statusText, "$(loading~spin) Coverage");
         statusBarToggler.toggle(true);
-        assert.equal(statusBarToggler.statusText, "$(loading~spin) No Coverage");
+        assert.equal(statusBarToggler.statusText, "$(loading~spin) Coverage");
         statusBarToggler.setLoading(false);
         assert.equal(statusBarToggler.statusText, "$(list-ordered) No Coverage");
     });


### PR DESCRIPTION
Closes #289.

~Feature works as expected but needs polished.~

@ryanluker thanks for having a look at the code whilst it was still in draft, I have refactored now and added an additional touch to alter the status bar tooltip text depending on the state of the workspace (watched vs unwatched).

Here is a v short demo (as it had to be under 10MB):

https://user-images.githubusercontent.com/37993418/121833778-66097a00-cd10-11eb-8be1-ad710bfc284e.mov

LMK if you'd like to see any changes.

Thanks,