### PR TITLE
replace cobertura parser with patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@cvrg-report/clover-json": "0.3.2",
-        "cobertura-parse": "github:vokal/cobertura-parse#53109a6",
+        "cobertura-parse": "github:fschwaiger/cobertura-parse#2914e67",
         "glob": "7.2.0",
         "jacoco-parse": "2.0.1",
         "lcov-parse": "1.0.0",
@@ -705,8 +705,7 @@
     },
     "node_modules/cobertura-parse": {
       "version": "1.0.6",
-      "resolved": "git+ssh://git@github.com/vokal/cobertura-parse.git#53109a677c995f5d2e90acd0fcd0b0788a6ec061",
-      "integrity": "sha512-URSczYq5zsro3oPU3IiT6dZM64a2NAWh/iIqmmRkFOe26/3pSq43EpFigTjP2WsNo51O9D8112jZsjtXfswTFQ==",
+      "resolved": "git+ssh://git@github.com/fschwaiger/cobertura-parse.git#2914e672ea2f4e0d11d9be5a0c1f0cf70f2a887d",
       "license": "MIT",
       "dependencies": {
         "mocha": "5.0.5",
@@ -3725,9 +3724,8 @@
       }
     },
     "cobertura-parse": {
-      "version": "git+ssh://git@github.com/vokal/cobertura-parse.git#53109a677c995f5d2e90acd0fcd0b0788a6ec061",
-      "integrity": "sha512-URSczYq5zsro3oPU3IiT6dZM64a2NAWh/iIqmmRkFOe26/3pSq43EpFigTjP2WsNo51O9D8112jZsjtXfswTFQ==",
-      "from": "cobertura-parse@github:vokal/cobertura-parse#53109a6",
+      "version": "git+ssh://git@github.com/fschwaiger/cobertura-parse.git#2914e672ea2f4e0d11d9be5a0c1f0cf70f2a887d",
+      "from": "cobertura-parse@github:fschwaiger/cobertura-parse#2914e67",
       "requires": {
         "mocha": "5.0.5",
         "xml2js": "0.4.19"

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
   },
   "dependencies": {
     "@cvrg-report/clover-json": "0.3.2",
-    "cobertura-parse": "github:vokal/cobertura-parse#53109a6",
+    "cobertura-parse": "github:fschwaiger/cobertura-parse#2914e67",
     "glob": "7.2.0",
     "jacoco-parse": "2.0.1",
     "lcov-parse": "1.0.0",


### PR DESCRIPTION
This is related to, and should resolve #304.

I did not have time yet nor do I have the experience to run the tests for this.