### PR TITLE
Upgrade cobertura parse to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@cvrg-report/clover-json": "0.3.2",
-        "cobertura-parse": "github:fschwaiger/cobertura-parse#2914e67",
+        "cobertura-parse": "github:fschwaiger/cobertura-parse#82b0333cb1580f6f337b5d44b04e2f5ca8711b7e",
         "glob": "7.2.0",
         "jacoco-parse": "2.0.1",
         "lcov-parse": "1.0.0",
@@ -1124,7 +1124,8 @@
     },
     "node_modules/cobertura-parse": {
       "version": "1.0.6",
-      "resolved": "git+ssh://git@github.com/fschwaiger/cobertura-parse.git#2914e672ea2f4e0d11d9be5a0c1f0cf70f2a887d",
+      "resolved": "git+ssh://git@github.com/fschwaiger/cobertura-parse.git#82b0333cb1580f6f337b5d44b04e2f5ca8711b7e",
+      "integrity": "sha512-jmdXlR+zi1w4O1mntUsYzACI3N8RlAJ68HTr5OMB9kaHnNbcY/uTwx5BBhzLsgLaYjPyc0uAWmKiU3NF6FLpaQ==",
       "license": "MIT",
       "dependencies": {
         "mocha": "5.0.5",
@@ -5073,8 +5074,9 @@
       }
     },
     "cobertura-parse": {
-      "version": "git+ssh://git@github.com/fschwaiger/cobertura-parse.git#2914e672ea2f4e0d11d9be5a0c1f0cf70f2a887d",
-      "from": "cobertura-parse@github:fschwaiger/cobertura-parse#2914e67",
+      "version": "git+ssh://git@github.com/fschwaiger/cobertura-parse.git#82b0333cb1580f6f337b5d44b04e2f5ca8711b7e",
+      "integrity": "sha512-jmdXlR+zi1w4O1mntUsYzACI3N8RlAJ68HTr5OMB9kaHnNbcY/uTwx5BBhzLsgLaYjPyc0uAWmKiU3NF6FLpaQ==",
+      "from": "cobertura-parse@github:fschwaiger/cobertura-parse#82b0333cb1580f6f337b5d44b04e2f5ca8711b7e",
       "requires": {
         "mocha": "5.0.5",
         "xml2js": "0.4.19"

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
   },
   "dependencies": {
     "@cvrg-report/clover-json": "0.3.2",
-    "cobertura-parse": "github:fschwaiger/cobertura-parse#2914e67",
+    "cobertura-parse": "github:fschwaiger/cobertura-parse#82b0333cb1580f6f337b5d44b04e2f5ca8711b7e",
     "glob": "7.2.0",
     "jacoco-parse": "2.0.1",
     "lcov-parse": "1.0.0",


### PR DESCRIPTION
Should fix #254 once the patch is applied to this extension repo.

### Notes
- I think I oops'd my windows machine github line endings as the lock file has changed a lot 😓.