### PR TITLE
chore: change activation event to onstartupfinished

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
     }
   },
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "scripts": {
     "lint": "eslint --ext .ts",


### PR DESCRIPTION
Changes the activation event from startup to onStartupFinished.

It wasn't having a big impact on startup time (at only around 23 ms) but since it can be put off, figured why not. (I'm trying pretty hard to improve my VSC performance. ^-^')

Read the related issue for more info!

### Related
* Closes https://github.com/ryanluker/vscode-coverage-gutters/issues/388