### PR TITLE
fix(preview): pass vscode.uri to live preview

### DIFF
--- a/src/coverage-system/coverage.ts
+++ b/src/coverage-system/coverage.ts
@@ -6,6 +6,7 @@ import {
     window,
     workspace,
     WorkspaceFolder,
+    Uri
 } from "vscode";
 
 import { Config } from "../extension/config";
@@ -22,7 +23,7 @@ export class Coverage {
      * Displays the quick picker vscode modal and lets the user choose a file path
      * Note: if only one path is given it will return early and not prompt.
      */
-    public async pickFile(filePaths: string[] | string, placeHolder: string): Promise<string | undefined> {
+    public async pickFile(filePaths: string[] | string, placeHolder: string): Promise<Uri | undefined> {
         let pickedFile: string | undefined;
         if (typeof filePaths === "string") {
             pickedFile = filePaths;
@@ -47,7 +48,7 @@ export class Coverage {
 
             pickedFile = item.description;
         }
-        return pickedFile;
+        return pickedFile ? Uri.file(pickedFile) : undefined;
     }
 
     public findReports(): Promise<string[]> {

--- a/test/coverage-system/coverage.test.ts
+++ b/test/coverage-system/coverage.test.ts
@@ -63,22 +63,22 @@ suite("Coverage Tests", () => {
         expect(stubWarningMessage.calledWith("Did not choose a file!"));
     });
 
-    test("#pickFile: Should return string if filePaths is a string @unit", async () => {
+    test("#pickFile: Should return vscode.uri if filePaths is a string @unit", async () => {
         const coverage = new Coverage(
             stubConfig,
         );
 
         const value = await coverage.pickFile("123", "nope");
 
-        expect(value).to.equal("123");
+        expect(value?.path).to.equal("/123");
     });
 
-    test("#pickFile: Should return string if filePaths is an array with one value @unit", async () => {
+    test("#pickFile: Should return vscode.uri if filePaths is an array with one value @unit", async () => {
         const coverage = new Coverage(
             stubConfig,
         );
 
         const value = await coverage.pickFile(["123"], "nope");
-        expect(value).to.equal("123");
+        expect(value?.path).to.equal("/123");
     });
 });


### PR DESCRIPTION
## Issue:
- closes #381

## Changes:
- convert file path string to vscode.Uri to support changes in live preview
- resolves the exception mentioned in https://github.com/microsoft/vscode-livepreview/issues/384

<img width="1720" alt="image" src="https://user-images.githubusercontent.com/5103752/221363950-71ff12e8-64f8-4578-ad81-a2c87c6c3756.png">
