### PR TITLE
Fix `Illegal argument: line must be non-negative`

### DIFF
--- a/src/coverage-system/renderer.ts
+++ b/src/coverage-system/renderer.ts
@@ -117,7 +117,7 @@ export class Renderer {
             return;
         }
         section.lines.details
-        .filter((detail) => detail.line >= 0)
+        .filter((detail) => detail.line > 0)
         .forEach((detail) => {
             const lineRange = new Range(detail.line - 1, 0, detail.line - 1, 0);
             if (detail.hit > 0) {
@@ -143,7 +143,7 @@ export class Renderer {
             return;
         }
         section.branches.details
-        .filter((detail) => detail.taken === 0 && detail.line >= 0)
+        .filter((detail) => detail.taken === 0 && detail.line > 0)
         .forEach((detail) => {
             const partialRange = new Range(detail.line - 1, 0, detail.line - 1, 0);
             // Evaluates to true if at least one element in range is equal to partialRange


### PR DESCRIPTION
---
name: Fix `Illegal argument: line must be non-negative`
about: Fix `Illegal argument: line must be non-negative` error by ignoring detail whose line attribute is 0

---

## Issue:
- Fix https://github.com/ryanluker/vscode-coverage-gutters/issues/424

## Changes:
- Change the filter in the renferer to ignore detail whose line attribute is 0.
