### PR TITLE
statusbar reports floor of coverage (resolves #423)

### DIFF
--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -175,7 +175,7 @@ export class CoverageService {
             const covered = fileCoverage?.lines?.hit;
             const total = fileCoverage?.lines?.found;
 
-            return this.statusBar.setCoverage(Math.round((covered / total) * 100 ));
+            return this.statusBar.setCoverage(Math.floor((covered / total) * 100 ));
         } catch {
             return this.statusBar.setCoverage(undefined);
         }


### PR DESCRIPTION
---
name: statusbar should report `Math.floor`
about: statusbar should report `Math.floor` instead of `Math.round`

---

## Issue:
- implements proposal in #423

## Changes:
- in a 200 line file with 1 missed line, statusbar would report 100%
  coverage with `Math.round`, which is misleading; there is still one
  missed line, so use `Math.floor` instead (which would report 99%
  coverage)
- @ryanluker
