### PR TITLE
Add cobertura.xml as default file name (supporting rust tarpaulin def…

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
             "lcov.info",
             "cov.xml",
             "coverage.xml",
+            "cobertura.xml",
             "jacoco.xml",
             "coverage.cobertura.xml"
           ],


### PR DESCRIPTION
…ault)

There are probably enough tools defaulting to `cobertura.xml` to justify including it. Although I do not really know how you reason about these things. https://grep.app/search?q=cobertura.xml (which is not a 100% correct outcome, but you get the idea...)

My particular use case is rust Tarpaulin https://github.com/xd009642/tarpaulin but there are more as seen above.