### PR TITLE
Ignore hidden directories by default within the glob pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "coverage-gutters.ignoredPathGlobs": {
           "type": "string",
           "scope": "resource",
-          "default": "**/{node_modules,venv,.venv,vendor}/**",
+          "default": "**/{node_modules,venv,vendor,.*}/**",
           "description": "paths that will be ignored by the extension"
         },
         "coverage-gutters.remotePathResolve": {


### PR DESCRIPTION
### Description
Based on a suggestion here https://github.com/ryanluker/vscode-coverage-gutters/issues/228#issuecomment-2185276726 around ignoring hidden directories / folders by default.