### PR TITLE
Changed the coverage updates from active to visible

### DIFF
--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -194,7 +194,7 @@ export class CoverageService {
     }
 
     private listenToEditorEvents() {
-        this.editorWatcher = window.onDidChangeActiveTextEditor(
+        this.editorWatcher = window.onDidChangeVisibleTextEditors(
             this.handleEditorEvents.bind(this),
         );
     }


### PR DESCRIPTION
When working in certain scenarios such as a split-view layout coverage for a file wasn’t displaying or updating if you switched to another file without actually focusing on the coverage file. For example, if one pane shows the coverage while another pane, which is in focus, controls which file is displayed in the first pane, the coverage pane would fail to refresh properly.

This pull request fixes that issue by changing the `listenToEditorEvents` listener from `onDidChangeActiveTextEditor` to `onDidChangeVisibleTextEditors`. As a result, coverage now updates correctly even when the file isn’t the active editor.