### PR TITLE
ignore and warn on unknown manual coverage file paths

### DIFF
--- a/src/files/filesloader.ts
+++ b/src/files/filesloader.ts
@@ -1,7 +1,7 @@
-import {readFile} from "fs";
+import { existsSync, readFile } from "fs";
 import glob from "glob";
-import {window, workspace, WorkspaceFolder} from "vscode";
-import {Config} from "../extension/config";
+import { window, workspace, WorkspaceFolder } from "vscode";
+import { Config } from "../extension/config";
 
 export class FilesLoader {
     private configStore: Config;
@@ -17,7 +17,14 @@ export class FilesLoader {
     public async findCoverageFiles(): Promise<Set<string>> {
         // Developers can manually define their absolute coverage paths
         if (this.configStore.manualCoverageFilePaths.length) {
-            return new Set(this.configStore.manualCoverageFilePaths);
+            const existingFiles = this.configStore.manualCoverageFilePaths.filter((file) => {
+                if (!existsSync(file)) {
+                    window.showWarningMessage(`manualCoverageFilePaths contains "${file}" which does not exist!`);
+                    return false;
+                }
+                return true;
+            });
+            return new Set(existingFiles);
         } else {
             const fileNames = this.configStore.coverageFileNames;
             const files = await this.findCoverageInWorkspace(fileNames);

--- a/test/files/filesloader.test.ts
+++ b/test/files/filesloader.test.ts
@@ -4,6 +4,7 @@ import sinon from "sinon";
 import * as vscode from "vscode";
 import { Config } from "../../src/extension/config";
 
+import path from "path";
 import { FilesLoader } from "../../src/files/filesloader";
 
 const stubConfig = sinon.createStubInstance(Config) as Config;
@@ -40,10 +41,34 @@ suite("FilesLoader Tests", () => {
     });
 
     test("findCoverageFiles returns manual coverage paths if set @unit", async () => {
-        const coverageFiles = ["test.js", "test2.js"];
+        const nodeTestFile = path.resolve(__dirname, "..", "..", "..", "example", "node", "lcov.info")
+        const rubyTestFile = path.resolve(__dirname, "..", "..", "..", "example", "ruby", "lcov.info")
+        const coverageFiles = [
+            nodeTestFile,
+            rubyTestFile,
+        ];
         stubConfig.manualCoverageFilePaths = coverageFiles;
         const filesLoader = new FilesLoader(stubConfig);
         const files = await filesLoader.findCoverageFiles();
         expect(new Set(coverageFiles)).to.deep.equal(files);
+    });
+
+    test("findCoverageFiles returns only manual coverage paths that exist @unit", async () => {
+        const nodeTestFile = path.resolve(__dirname, "..", "..", "..", "example", "node", "lcov.info")
+        const unknownTestFile = path.resolve(__dirname, "..", "..", "..", "example", "unknown", "lcov.info")
+        const rubyTestFile = path.resolve(__dirname, "..", "..", "..", "example", "ruby", "lcov.info")
+        const coverageFiles = [
+            nodeTestFile,
+            unknownTestFile,
+            rubyTestFile,
+        ];
+        stubConfig.manualCoverageFilePaths = coverageFiles;
+        const filesLoader = new FilesLoader(stubConfig);
+        const files = await filesLoader.findCoverageFiles();
+        expect(new Set([
+            nodeTestFile,
+            // unknownTestFile does not exist so it should not be included
+            rubyTestFile,
+        ])).to.deep.equal(files);
     });
 });


### PR DESCRIPTION
This extension silently fails if a file in the `coverage-gutters.manualCoverageFilePaths` setting does not exist.

This PR filters out any files from that setting that do not exists and raises a warning to the user:

<img width="959" alt="image" src="https://github.com/user-attachments/assets/2c2fc73f-c8df-4ef2-821a-ba612ed6cad8" />

By the way, thanks for this extension!  Really useful!