### PR TITLE
copy (and update) package.json to out directory to enable mocking in integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     "pretty": "eslint --fix --ext .ts",
     "pre-commit": "lint-staged",
     "compile-tests": "tsc -p . --outDir out",
-    "pretest": "npm run compile-tests",
+    "pretest": "npm run compile-tests && node ./out/test/createTestPackageJson.js",
     "test": "node ./out/test/runTest.js",
     "build": "npm install && npm run lint && npm run compile",
     "prepare": "husky install",

--- a/src/coverage-system/coverageservice.ts
+++ b/src/coverage-system/coverageservice.ts
@@ -194,8 +194,10 @@ export class CoverageService {
     }
 
     private listenToEditorEvents() {
-        this.editorWatcher = window.onDidChangeVisibleTextEditors(
+        this.editorWatcher = window.onDidChangeActiveTextEditor(
             this.handleEditorEvents.bind(this),
         );
+
+
     }
 }

--- a/test/createTestPackageJson.ts
+++ b/test/createTestPackageJson.ts
@@ -1,0 +1,15 @@
+import path from "path";
+import fs from "fs";
+
+const packageJson = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8")
+);
+
+const testPackageJsonPath = path.resolve(__dirname, "..", "package.json");
+const testPackageJsonContents = JSON.stringify(
+    { ...packageJson, main: "./src/extension" },
+    null,
+    2
+);
+
+fs.writeFileSync(testPackageJsonPath, testPackageJsonContents, "utf-8");

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -34,6 +34,7 @@ suite("Extension Tests", function () {
         await checkCoverage(() => {
             // Look for exact coverage on the file
             const spyCall = decorationSpy.getCall(0);
+            expect(spyCall).to.not.be.null;
             if (spyCall) {
                 const cachedLines: ICoverageLines = spyCall.args[1];
                 expect(cachedLines.full).to.have.lengthOf(3);
@@ -55,6 +56,7 @@ suite("Extension Tests", function () {
         await checkCoverage(() => {
             // Look for exact coverage on the file
             const spyCall = decorationSpy.getCall(0);
+            expect(spyCall).to.not.be.null;
             if (spyCall) {
                 const cachedLines: ICoverageLines = spyCall.args[1];
                 expect(cachedLines.full).to.have.lengthOf(14);
@@ -76,6 +78,7 @@ suite("Extension Tests", function () {
         await checkCoverage(() => {
             // Look for exact coverage on the file
             const spyCall = decorationSpy.getCall(0);
+            expect(spyCall).to.not.be.null;
             if (spyCall) {
                 const cachedLines: ICoverageLines = spyCall.args[1];
                 expect(cachedLines.full).to.have.lengthOf(3);
@@ -138,6 +141,7 @@ suite("Extension Tests", function () {
         await checkCoverage(() => {
             // Look for exact coverage on the file
             const spyCall = decorationSpy.getCall(0);
+            expect(spyCall).to.not.be.null;
             if (spyCall) {
                 const cachedLines: ICoverageLines = spyCall.args[1];
                 expect(cachedLines.full).to.have.lengthOf(4);
@@ -159,6 +163,7 @@ suite("Extension Tests", function () {
         await checkCoverage(() => {
             // Look for exact coverage on the file
             const spyCall = decorationSpy.getCall(0);
+            expect(spyCall).to.not.be.null;
             if (spyCall) {
                 const cachedLines: ICoverageLines = spyCall.args[1];
                 expect(cachedLines.none).to.have.lengthOf(6);
@@ -180,6 +185,7 @@ suite("Extension Tests", function () {
         await checkCoverage(() => {
             // Look for exact coverage on the file
             const spyCall = decorationSpy.getCall(0);
+            expect(spyCall).to.not.be.null;
             if (spyCall) {
                 const cachedLines: ICoverageLines = spyCall.args[1];
                 expect(cachedLines.full).to.have.lengthOf(3);
@@ -201,6 +207,7 @@ suite("Extension Tests", function () {
         await checkCoverage(() => {
             // Look for exact coverage on the file
             const spyCall = decorationSpy.getCall(0);
+            expect(spyCall).to.not.be.null;
             if (spyCall) {
                 const cachedLines: ICoverageLines = spyCall.args[1];
                 expect(cachedLines.full).to.have.lengthOf(4);
@@ -237,8 +244,10 @@ suite("Extension Tests", function () {
 
             await checkCoverage(() => {
                 // Look for exact coverage on the file
-                if (decorationSpy.getCall(i)) {
-                    const cachedLines: ICoverageLines = decorationSpy.getCall(i).args[1];
+                const spyCall = decorationSpy.getCall(i);
+                expect(spyCall).to.not.be.null;
+                if (spyCall) {
+                    const cachedLines: ICoverageLines = spyCall.args[1];
                     expect(cachedLines.full).to.have.lengthOf(linesCovered);
                     expect(cachedLines.none).to.have.lengthOf(linesNotCovered);
                 }
@@ -258,8 +267,10 @@ suite("Extension Tests", function () {
 
         await checkCoverage(() => {
             // Look for exact coverage on the ruby file
-            if (decorationSpy.getCall(0)) {
-                const cachedLines: ICoverageLines = decorationSpy.getCall(0).args[1];
+            const spyCall = decorationSpy.getCall(0);
+            expect(spyCall).to.not.be.null;
+            if (spyCall) {
+                const cachedLines: ICoverageLines = spyCall.args[1];
                 expect(cachedLines.full).to.have.lengthOf(4);
                 expect(cachedLines.partial).to.have.lengthOf(1);
                 expect(cachedLines.none).to.have.lengthOf(1);
@@ -288,8 +299,10 @@ suite("Extension Tests", function () {
 
         await checkCoverage(() => {
             // Look for exact coverage on the file
-            if (decorationSpy.getCall(0)) {
-                const cachedLines: ICoverageLines = decorationSpy.getCall(0).args[1];
+            const spyCall = decorationSpy.getCall(0);
+            expect(spyCall).to.not.be.null;
+            if (spyCall) {
+                const cachedLines: ICoverageLines = spyCall.args[1];
                 expect(cachedLines.full).to.have.lengthOf(14);
                 expect(cachedLines.none).to.have.lengthOf(4);
                 expect(cachedLines.partial).to.have.lengthOf(7);
@@ -309,9 +322,11 @@ suite("Extension Tests", function () {
         await vscode.window.showTextDocument(testJSDocument);
 
         await checkCoverage(() => {
-            if (decorationSpy.getCall(0)) {
+            const spyCall = decorationSpy.getCall(0);
+            expect(spyCall).to.not.be.null;
+            if (spyCall) {
                 // Look for exact coverage on the file
-                const jsCachedLines: ICoverageLines = decorationSpy.getCall(0).args[1];
+                const jsCachedLines: ICoverageLines = spyCall.args[1];
                 expect(jsCachedLines.full).to.have.lengthOf(14);
                 expect(jsCachedLines.none).to.have.lengthOf(4);
                 expect(jsCachedLines.partial).to.have.lengthOf(7);
@@ -326,9 +341,11 @@ suite("Extension Tests", function () {
         await wait(500);
 
         await checkCoverage(() => {
-            if (decorationSpy.getCall(1)) {
+            const spyCall = decorationSpy.getCall(1);
+            expect(spyCall).to.not.be.null;
+            if (spyCall) {
                 // Look for exact coverage on the file
-                const javaCachedLines: ICoverageLines = decorationSpy.getCall(1).args[1];
+                const javaCachedLines: ICoverageLines = spyCall.args[1];
                 expect(javaCachedLines.full).to.have.lengthOf(4);
                 expect(javaCachedLines.none).to.have.lengthOf(3);
             }
@@ -353,25 +370,25 @@ suite("Extension Tests", function () {
             setCoverageSpy.resetHistory();
             await vscode.window.showTextDocument(testJSDocument, vscode.ViewColumn.One);
 
-            expect(setCoverageSpy.calledWith(84))
+            expect(setCoverageSpy.calledWith(84)).to.be.true;
             setCoverageSpy.resetHistory();
 
             const [testJavaCoverage] = await vscode.workspace.findFiles("**/App.java", "**/node_modules/**");
             const testJavaDocument = await vscode.workspace.openTextDocument(testJavaCoverage);
 
-            await vscode.window.showTextDocument(testJavaDocument, vscode.ViewColumn.Two);
+            await vscode.window.showTextDocument(testJavaDocument, vscode.ViewColumn.Two, false);
 
-            expect(setCoverageSpy.calledWith(57));
+            expect(setCoverageSpy.calledWith(57)).to.be.true;
             setCoverageSpy.resetHistory();
 
             await vscode.commands.executeCommand("workbench.action.previousEditor");
 
-            expect(setCoverageSpy.calledWith(84));
+            expect(setCoverageSpy.calledWith(84)).to.be.true;
             setCoverageSpy.resetHistory();
 
             await vscode.commands.executeCommand("workbench.action.closeAllEditors");
 
-            expect(setCoverageSpy.calledWith(undefined));
+            expect(setCoverageSpy.calledWith(undefined)).to.be.true;
 
             setCoverageSpy.restore();
             return vscode.commands.executeCommand("coverage-gutters.removeWatch");

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -8,7 +8,7 @@ import {
 
 async function main() {
     try {
-        const extensionDevelopmentPath = path.resolve(__dirname, "../../");
+        const extensionDevelopmentPath = path.resolve(__dirname, "../../out");
         const extensionTestsPath = path.resolve(__dirname, "index");
 
         // Add the dependent extension for test coverage preview functionality


### PR DESCRIPTION
Closes #479 

The underlying issue is that sinon cannot mock modules in the bundled `dist` folder. In order for this to work we need to copy the package.json from the root folder into the `out/` folder (generated by `compile-tests`) and update the `main` entry to point at `src/extension`.

I have taken the opportunity to update the tests in `extension.tests.ts` to ensure they are now testing the correct things.