### PR TITLE
Add retry option to launchArgs in runTest

### DIFF
--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -8,7 +8,8 @@ import { StatusBarToggler } from "../src/extension/statusbartoggler";
 import { Gutters, PREVIEW_COMMAND } from "../src/extension/gutters";
 
 suite("Extension Tests", function () {
-    const disposables: v
+    const disposables: vscode.Disposable[] = [];
+
     afterEach(() => {
         // Clear mocks after each test to avoid cascading failures due to one test failing
         sinon.restore();
@@ -70,6 +71,8 @@ suite("Extension Tests", function () {
         // can sometimes fail on this E2E test.
         this.retries(3);
 
+        const decorationSpy = sinon.spy(Renderer.prototype, "setDecorationsForEditor");
+        expect(true).to.be.false
         const decorationSpy = sinon.spy(Renderer.prototype, "setDecorationsForEditor");
         expect(true).to.be.false;
         const testCoverage = await vscode.workspace.findFiles("**/remote-test-coverage.js", "**/node_modules/**");

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -9,11 +9,6 @@ import { Gutters, PREVIEW_COMMAND } from "../src/extension/gutters";
 
 suite("Extension Tests", function () {
     const disposables: vscode.Disposable[] = [];
-    
-    // Adds a couple extra retries as the macos nightly builds can sometimes 
-    // fail on the E2E tests.
-    this.retries(3);
-    
     afterEach(() => {
         // Clear mocks after each test to avoid cascading failures due to one test failing
         sinon.restore();

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -9,6 +9,9 @@ import { Gutters, PREVIEW_COMMAND } from "../src/extension/gutters";
 
 suite("Extension Tests", function () {
     const disposables: vscode.Disposable[] = [];
+    
+    // Adds a couple extra retries as the macos nightly builds can sometimes 
+    // fail on the E2E tests.
     this.retries(3);
     
     afterEach(() => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -73,8 +73,7 @@ suite("Extension Tests", function () {
 
         const decorationSpy = sinon.spy(Renderer.prototype, "setDecorationsForEditor");
         expect(true).to.be.false
-        const decorationSpy = sinon.spy(Renderer.prototype, "setDecorationsForEditor");
-        expect(true).to.be.false;
+
         const testCoverage = await vscode.workspace.findFiles("**/remote-test-coverage.js", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
         await vscode.window.showTextDocument(testDocument);

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -8,7 +8,7 @@ import { StatusBarToggler } from "../src/extension/statusbartoggler";
 import { Gutters, PREVIEW_COMMAND } from "../src/extension/gutters";
 
 suite("Extension Tests", function () {
-    const disposables: vscode.Disposable[] = [];
+    const disposables: v
     afterEach(() => {
         // Clear mocks after each test to avoid cascading failures due to one test failing
         sinon.restore();
@@ -66,6 +66,10 @@ suite("Extension Tests", function () {
     });
 
     test("Run display coverage on a test file that has coverages generated remotely @integration", async () => {
+        // NOTE: Adds a couple extra retries as the macos nightly builds 
+        // can sometimes fail on this E2E test.
+        this.retries(3);
+
         const decorationSpy = sinon.spy(Renderer.prototype, "setDecorationsForEditor");
         expect(true).to.be.false;
         const testCoverage = await vscode.workspace.findFiles("**/remote-test-coverage.js", "**/node_modules/**");

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -9,7 +9,8 @@ import { Gutters, PREVIEW_COMMAND } from "../src/extension/gutters";
 
 suite("Extension Tests", function () {
     const disposables: vscode.Disposable[] = [];
-
+    this.retries(3);
+    
     afterEach(() => {
         // Clear mocks after each test to avoid cascading failures due to one test failing
         sinon.restore();

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -72,7 +72,7 @@ suite("Extension Tests", function () {
 
     test("Run display coverage on a test file that has coverages generated remotely @integration", async () => {
         const decorationSpy = sinon.spy(Renderer.prototype, "setDecorationsForEditor");
-
+        expect(true).to.be.false;
         const testCoverage = await vscode.workspace.findFiles("**/remote-test-coverage.js", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
         await vscode.window.showTextDocument(testDocument);

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -67,13 +67,8 @@ suite("Extension Tests", function () {
     });
 
     test("Run display coverage on a test file that has coverages generated remotely @integration", async () => {
-        // NOTE: Adds a couple extra retries as the macos nightly builds 
-        // can sometimes fail on this E2E test.
-        this.retries(3);
-
-        const decorationSpy = sinon.spy(Renderer.prototype, "setDecorationsForEditor");
         expect(true).to.be.false
-
+        const decorationSpy = sinon.spy(Renderer.prototype, "setDecorationsForEditor");
         const testCoverage = await vscode.workspace.findFiles("**/remote-test-coverage.js", "**/node_modules/**");
         const testDocument = await vscode.workspace.openTextDocument(testCoverage[0]);
         await vscode.window.showTextDocument(testDocument);

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,12 +4,9 @@ import { resolve } from "path";
 
 export function run(): Promise<void> {
     // Create the mocha test
-    // NOTE: Adds a couple extra retries as the macos nightly builds 
-    // can sometimes fail on the E2E tests.
     const mocha = new Mocha({
         color: true,
         ui: "tdd",
-        retries: 3,
     });
 
     // Apply regex to run subset of tests (integration vs unit)

--- a/test/index.ts
+++ b/test/index.ts
@@ -25,6 +25,7 @@ export function run(): Promise<void> {
             files.forEach((f) => mocha.addFile(resolve(testsRoot, f)));
             try {
                 // Run the mocha test
+                mocha.retries(3);
                 mocha.run((failures) => {
                     if (failures > 0) {
                         e(new Error(`${failures} tests failed.`));

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,9 +4,12 @@ import { resolve } from "path";
 
 export function run(): Promise<void> {
     // Create the mocha test
+    // NOTE: Adds a couple extra retries as the macos nightly builds 
+    // can sometimes fail on the E2E tests.
     const mocha = new Mocha({
         color: true,
         ui: "tdd",
+        retries: 3,
     });
 
     // Apply regex to run subset of tests (integration vs unit)

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -10,7 +10,10 @@ async function main() {
             version: "insiders",
             extensionDevelopmentPath,
             extensionTestsPath,
-            launchArgs: ["example/example.code-workspace"],
+            launchArgs: [
+                "example/example.code-workspace",
+                "--retries 3",
+            ],
         })
 
         console.info("Success!");

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -10,10 +10,7 @@ async function main() {
             version: "insiders",
             extensionDevelopmentPath,
             extensionTestsPath,
-            launchArgs: [
-                "example/example.code-workspace",
-                "--retries 3",
-            ],
+            launchArgs: ["example/example.code-workspace"],
         })
 
         console.info("Success!");


### PR DESCRIPTION
Attempt to add automatic retries to the ci builds to prevent failure email spam.

### Extra info:
https://mochajs.org/declaring/retrying-tests/