### PR TITLE
Adjust nightly tests timing for linux and other operating systems

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Continuous Integration
 on:
   schedule:
+    # Weekly on Mondays for Windows / Mac
+    - cron: '0 0 * * 1'
+    # Nightly builds for Linux (cheapest)
     - cron: '0 0 * * *'
   pull_request:
   push:
@@ -12,6 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+    if: |
+      github.event_name != 'schedule' ||
+      (github.event.schedule == '0 0 * * *' && matrix.os == 'ubuntu-latest') ||
+      (github.event.schedule == '0 0 * * 1' && matrix.os != 'ubuntu-latest')
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,11 @@ name: Continuous Integration
 on:
   schedule:
     # Weekly on Mondays for Windows / Mac
-    - cron: '0 0 * * 1'
+    - cron: '0 13 * * 1'
+      timezone: 'America/Vancouver'
     # Nightly builds for Linux (cheapest)
-    - cron: '0 0 * * *'
+    - cron: '0 13 * * *'
+      timezone: 'America/Vancouver'
   pull_request:
   push:
     branches:


### PR DESCRIPTION
To ease cost burdens (mac especially is expensive to run all the time), only linux will be nightly.